### PR TITLE
Update ring to 0.14.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ pretty_assertions = "^0.1.2"
 
 [dependencies]
 base64 = "~0.6.0"
-ring = "^0.13.2"
+ring = "^0.14.5"
 time = "^0.1.32"
 url = "1.4.0"
 rand = "0.3"


### PR DESCRIPTION
ring yanks old versions regularly and will yank 0.13.5 soon (https://github.com/briansmith/ring/issues/774).
This PR updates ring to the latest version.