### PR TITLE
Modernize rust-hawk.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/taskcluster/rust-hawk"
 documentation = "https://docs.rs/hawk/"
 homepage = "https://docs.rs/hawk/"
 description = "Hawk Implementation for Rust"
+edition = "2018"
 
 [dev-dependencies]
 pretty_assertions = "^0.1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,4 @@ ring = "^0.14.5"
 time = "^0.1.32"
 url = "1.4.0"
 rand = "0.3"
-error-chain = "^0.11.0-rc.2"
+failure = { version = "0.1.5", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ pretty_assertions = "^0.1.2"
 [dependencies]
 base64 = "0.10.1"
 ring = "0.14.6"
-time = "0.1.42"
 url = "1.7.2"
 rand = "0.6.5"
 failure = { version = "0.1.5", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,9 @@ edition = "2018"
 pretty_assertions = "^0.1.2"
 
 [dependencies]
-base64 = "~0.6.0"
-ring = "^0.14.5"
-time = "^0.1.32"
-url = "1.4.0"
-rand = "0.3"
+base64 = "0.10.1"
+ring = "0.14.6"
+time = "0.1.42"
+url = "1.7.2"
+rand = "0.6.5"
 failure = { version = "0.1.5", features = ["derive"] }

--- a/src/bewit.rs
+++ b/src/bewit.rs
@@ -1,4 +1,3 @@
-use base64;
 use crate::mac::Mac;
 use crate::error::*;
 use std::str;

--- a/src/bewit.rs
+++ b/src/bewit.rs
@@ -1,6 +1,6 @@
 use base64;
-use mac::Mac;
-use error::*;
+use crate::mac::Mac;
+use crate::error::*;
 use std::str;
 use std::str::FromStr;
 use time::Timespec;
@@ -113,9 +113,9 @@ impl<'a> FromStr for Bewit<'a> {
 mod test {
     use super::*;
     use std::str::FromStr;
-    use credentials::Key;
+    use crate::credentials::Key;
     use ring::digest;
-    use mac::{Mac, MacType};
+    use crate::mac::{Mac, MacType};
 
     fn make_mac() -> Mac {
         let key = Key::new(vec![11u8, 19, 228, 209, 79, 189, 200, 59, 166, 47, 86, 254, 235, 184,

--- a/src/bewit.rs
+++ b/src/bewit.rs
@@ -35,10 +35,11 @@ impl<'a> Bewit<'a> {
 
     /// Generate the fully-encoded string for this Bewit
     pub fn to_str(&self) -> String {
+        use base64::display::Base64Display;
         let raw = format!("{}\\{}\\{}\\{}",
                           self.id,
                           self.exp.duration_since(UNIX_EPOCH).unwrap_or_default().as_secs(),
-                          base64::encode(self.mac.as_ref()),
+                          Base64Display::with_config(self.mac.as_ref(), base64::STANDARD),
                           match self.ext {
                               Some(ref cow) => cow.as_ref(),
                               None => "",

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -9,15 +9,15 @@ pub struct Key(hmac::SigningKey);
 
 impl Key {
     pub fn new<B>(key: B, algorithm: &'static digest::Algorithm) -> Key
-        where B: Into<Vec<u8>>
+        where B: AsRef<[u8]>
     {
-        Key(hmac::SigningKey::new(algorithm, key.into().as_ref()))
+        Key(hmac::SigningKey::new(algorithm, key.as_ref()))
     }
 
     pub fn sign(&self, data: &[u8]) -> Vec<u8> {
         let digest = hmac::sign(&self.0, data);
         let mut mac = vec![0; self.0.digest_algorithm().output_len];
-        mac.clone_from_slice(digest.as_ref());
+        mac.copy_from_slice(digest.as_ref());
         mac
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,12 +1,59 @@
-error_chain! {
-    errors {
-        HeaderParseError {
-            description("Unparseable Hawk header")
-        }
-    }
+use failure::Fail;
 
-    foreign_links {
-        Io(::std::io::Error);
-        Decode(::base64::DecodeError);
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Fail, Debug)]
+pub enum Error {
+    #[fail(display = "Unparseable Hawk header: {}", _0)]
+    HeaderParseError(String),
+
+    #[fail(display = "Invalid url: {}", _0)]
+    InvalidUrl(String),
+
+    #[fail(display = "Missing `ts` attribute in Hawk header")]
+    MissingTs,
+
+    #[fail(display = "Missing `nonce` attribute in Hawk header")]
+    MissingNonce,
+
+    #[fail(display = "{}", _0)]
+    InvalidBewit(#[fail(cause)] InvalidBewit),
+
+    #[fail(display = "{}", _0)]
+    Io(#[fail(cause)] std::io::Error),
+
+    #[fail(display = "Base64 Decode error: {}", _0)]
+    Decode(#[fail(cause)] base64::DecodeError),
+}
+
+#[derive(Fail, Debug, PartialEq)]
+pub enum InvalidBewit {
+    #[fail(display = "Invalid bewit format")]
+    Format,
+    #[fail(display = "Invalid bewit id")]
+    Id,
+    #[fail(display = "Invalid bewit exp")]
+    Exp,
+    #[fail(display = "Invalid bewit mac")]
+    Mac,
+    #[fail(display = "Invalid bewit ext")]
+    Ext,
+}
+
+impl From<base64::DecodeError> for Error {
+    fn from(e: base64::DecodeError) -> Self {
+        Error::Decode(e)
+    }
+}
+
+impl From<std::io::Error> for Error {
+    fn from(e: std::io::Error) -> Self {
+        Error::Io(e)
+    }
+}
+
+impl From<InvalidBewit> for Error {
+    fn from(e: InvalidBewit) -> Self {
+        Error::InvalidBewit(e)
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -24,6 +24,9 @@ pub enum Error {
 
     #[fail(display = "Base64 Decode error: {}", _0)]
     Decode(#[fail(cause)] base64::DecodeError),
+
+    #[fail(display = "RNG error: {}", _0)]
+    Rng(#[fail(cause)] rand::Error),
 }
 
 #[derive(Fail, Debug, PartialEq)]
@@ -51,6 +54,13 @@ impl From<std::io::Error> for Error {
         Error::Io(e)
     }
 }
+
+impl From<rand::Error> for Error {
+    fn from(e: rand::Error) -> Self {
+        Error::Rng(e)
+    }
+}
+
 
 impl From<InvalidBewit> for Error {
     fn from(e: InvalidBewit) -> Self {

--- a/src/header.rs
+++ b/src/header.rs
@@ -1,4 +1,4 @@
-use base64;
+use base64::display::Base64Display;
 use std::fmt;
 use std::str::FromStr;
 use crate::mac::Mac;
@@ -83,7 +83,7 @@ impl Header {
             sep = ", ";
         }
         if let Some(ref mac) = self.mac {
-            write!(f, "{}mac=\"{}\"", sep, base64::encode(mac))?;
+            write!(f, "{}mac=\"{}\"", sep, Base64Display::with_config(mac, base64::STANDARD))?;
             sep = ", ";
         }
         if let Some(ref ext) = self.ext {
@@ -91,7 +91,7 @@ impl Header {
             sep = ", ";
         }
         if let Some(ref hash) = self.hash {
-            write!(f, "{}hash=\"{}\"", sep, base64::encode(hash))?;
+            write!(f, "{}hash=\"{}\"", sep, Base64Display::with_config(hash, base64::STANDARD))?;
             sep = ", ";
         }
         if let Some(ref app) = self.app {

--- a/src/header.rs
+++ b/src/header.rs
@@ -1,8 +1,8 @@
 use base64;
 use std::fmt;
 use std::str::FromStr;
-use mac::Mac;
-use error::*;
+use crate::mac::Mac;
+use crate::error::*;
 use time::Timespec;
 
 /// Representation of a Hawk `Authorization` header value (the part following "Hawk ").
@@ -220,7 +220,7 @@ mod test {
     use super::Header;
     use time::Timespec;
     use std::str::FromStr;
-    use mac::Mac;
+    use crate::mac::Mac;
 
     #[test]
     fn illegal_id() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,11 +10,8 @@
 //! Request instance, which will generate the header.
 //!
 //! ```
-//! #[macro_use] extern crate pretty_assertions;
-//! extern crate time;
-//! extern crate hawk;
-//!
 //! use hawk::{RequestBuilder, Credentials, Key, SHA256, PayloadHasher};
+//! use std::time::{Duration, UNIX_EPOCH};
 //!
 //! fn main() {
 //!     // provide the Hawk id and key
@@ -47,11 +44,9 @@
 //! Request instance, and use the request to validate the header.
 //!
 //! ```
-//! extern crate time;
-//! extern crate hawk;
-//!
 //! use hawk::{RequestBuilder, Header, Key, SHA256};
 //! use hawk::mac::Mac;
+//! use std::time::{Duration, UNIX_EPOCH};
 //!
 //! fn main() {
 //!    let mac = Mac::from(vec![7, 22, 226, 240, 84, 78, 49, 75, 115, 144, 70,
@@ -59,7 +54,7 @@
 //!                             154, 213, 118, 19, 63, 183, 108, 215, 134, 118, 115]);
 //!    // get the header (usually from the received request; constructed directly here)
 //!    let hdr = Header::new(Some("dh37fgj492je"),
-//!                          Some(time::Timespec::new(1353832234, 0)),
+//!                          Some(UNIX_EPOCH + Duration::new(1353832234, 0)),
 //!                          Some("j4h3g2"),
 //!                          Some(mac),
 //!                          Some("my-ext-value"),
@@ -74,12 +69,12 @@
 //!        .request();
 //!
 //!    let key = Key::new(vec![99u8; 32], &SHA256);
-//!    if !request.validate_header(&hdr, &key, time::Duration::weeks(5200)) {
+//!    let one_week_in_secs = 7 * 24 * 60 * 60;
+//!    if !request.validate_header(&hdr, &key, Duration::from_secs(5200 * one_week_in_secs)) {
 //!        panic!("header validation failed. Is it 2117 already?");
 //!    }
 //! }
 extern crate base64;
-extern crate time;
 extern crate ring;
 extern crate url;
 extern crate rand;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,25 +92,25 @@ extern crate pretty_assertions;
 extern crate error_chain;
 
 mod header;
-pub use header::Header;
+pub use crate::header::Header;
 
 mod credentials;
-pub use credentials::{Credentials, Key};
+pub use crate::credentials::{Credentials, Key};
 
 mod request;
-pub use request::{Request, RequestBuilder};
+pub use crate::request::{Request, RequestBuilder};
 
 mod response;
-pub use response::{Response, ResponseBuilder};
+pub use crate::response::{Response, ResponseBuilder};
 
 mod error;
-pub use error::*;
+pub use crate::error::*;
 
 mod payload;
-pub use payload::PayloadHasher;
+pub use crate::payload::PayloadHasher;
 
 mod bewit;
-pub use bewit::Bewit;
+pub use crate::bewit::Bewit;
 
 pub mod mac;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,10 +74,6 @@
 //!        panic!("header validation failed. Is it 2117 already?");
 //!    }
 //! }
-extern crate base64;
-extern crate ring;
-extern crate url;
-extern crate rand;
 
 #[cfg(test)]
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,9 +88,6 @@ extern crate rand;
 #[macro_use]
 extern crate pretty_assertions;
 
-#[macro_use]
-extern crate error_chain;
-
 mod header;
 pub use crate::header::Header;
 

--- a/src/mac.rs
+++ b/src/mac.rs
@@ -1,5 +1,5 @@
 use crate::credentials::Key;
-use base64;
+use base64::{STANDARD, display::Base64Display};
 use ring::constant_time;
 use std::io::Write;
 use std::ops::Deref;
@@ -32,32 +32,40 @@ impl Mac {
                hash: Option<&[u8]>,
                ext: Option<&str>)
                -> Result<Mac> {
-        let mut buffer: Vec<u8> = vec![];
+        // Note: there's a \n after each item.
+        let mut buffer: Vec<u8> = Vec::with_capacity(
+            15 + 1 + // mac_type (worst case since it doesn't really matter)
+            10 + 1 + // ts (in practice this will be 10 bytes)
+            nonce.len() + 1 +
+            host.len() + 1 +
+            6 + 1 + // Longer than 6 bytes of port seems very unlikely
+            path.len() + 1 +
+            hash.map_or(0, |h| h.len() * 4 / 3) + 1 +
+            ext.map_or(0, |e| e.len()) + 1
+        );
 
-        writeln!(buffer,
-                 "{}",
-                 match mac_type {
-                     MacType::Header => "hawk.1.header",
-                     MacType::Response => "hawk.1.response",
-                     MacType::Bewit => "hawk.1.bewit",
-                 })?;
-        writeln!(buffer, "{}", ts.sec)?;
-        writeln!(buffer, "{}", nonce)?;
-        writeln!(buffer, "{}", method)?;
-        writeln!(buffer, "{}", path)?;
-        writeln!(buffer, "{}", host)?;
-        writeln!(buffer, "{}", port)?;
+        writeln!(
+            buffer,
+            "{mac_type}\n{ts}\n{nonce}\n{method}\n{path}\n{host}\n{port}",
+            mac_type = match mac_type {
+                MacType::Header => "hawk.1.header",
+                MacType::Response => "hawk.1.response",
+                MacType::Bewit => "hawk.1.bewit",
+            },
+            ts = ts.sec,
+            nonce = nonce,
+            method = method,
+            path = path,
+            host = host,
+            port = port,
+        )?;
 
         if let Some(h) = hash {
-            writeln!(buffer, "{}", base64::encode(h))?;
+            writeln!(buffer, "{}", Base64Display::with_config(h, STANDARD))?;
         } else {
             writeln!(buffer)?;
         }
-
-        match ext {
-            Some(e) => writeln!(buffer, "{}", e)?,
-            None => writeln!(buffer)?,
-        };
+        writeln!(buffer, "{}", ext.unwrap_or_default())?;
 
         Ok(Mac(key.sign(buffer.as_ref())))
     }

--- a/src/mac.rs
+++ b/src/mac.rs
@@ -1,9 +1,9 @@
-use credentials::Key;
+use crate::credentials::Key;
 use base64;
 use ring::constant_time;
 use std::io::Write;
 use std::ops::Deref;
-use error::*;
+use crate::error::*;
 use time;
 
 /// The kind of MAC calcuation (corresponding to the first line of the message)
@@ -94,7 +94,7 @@ impl PartialEq for Mac {
 mod test {
     use super::{Mac, MacType};
     use time::Timespec;
-    use credentials::Key;
+    use crate::credentials::Key;
     use ring::digest;
 
     fn key() -> Key {

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,4 +1,3 @@
-use base64;
 use url::Url;
 use crate::mac::{Mac, MacType};
 use crate::header::Header;

--- a/src/request.rs
+++ b/src/request.rs
@@ -6,8 +6,7 @@ use crate::header::Header;
 use crate::response::ResponseBuilder;
 use crate::bewit::Bewit;
 use crate::credentials::{Credentials, Key};
-use rand;
-use rand::Rng;
+use rand::prelude::*;
 use crate::error::*;
 use time::{now, Duration};
 use std::str;
@@ -48,7 +47,7 @@ impl<'a> Request<'a> {
     /// Create a new Header for this request, inventing a new nonce and setting the
     /// timestamp to the current time.
     pub fn make_header(&self, credentials: &Credentials) -> Result<Header> {
-        let nonce = random_string(10);
+        let nonce = random_string(10)?;
         self.make_header_full(credentials, time::now().to_timespec(), nonce)
     }
 
@@ -353,11 +352,11 @@ impl<'a> RequestBuilder<'a> {
 
 /// Create a random string with `bytes` bytes of entropy.  The string
 /// is base64-encoded. so it will be longer than bytes characters.
-fn random_string(bytes: usize) -> String {
-    let mut rng = rand::thread_rng();
+fn random_string(bytes: usize) -> Result<String> {
+    let mut rng = thread_rng();
     let mut bytes = vec![0u8; bytes];
-    rng.fill_bytes(&mut bytes);
-    base64::encode(&bytes)
+    rng.try_fill_bytes(&mut bytes)?;
+    Ok(base64::encode(&bytes))
 }
 
 #[cfg(test)]

--- a/src/request.rs
+++ b/src/request.rs
@@ -343,9 +343,9 @@ impl<'a> RequestBuilder<'a> {
 
     fn parse_url(url: &'a Url) -> Result<(&'a str, u16, &'a str)> {
         let host = url.host_str()
-            .ok_or_else(|| format!("url {} has no host", url))?;
+            .ok_or_else(|| Error::InvalidUrl(format!("url {} has no host", url)))?;
         let port = url.port_or_known_default()
-            .ok_or_else(|| format!("url {} has no port", url))?;
+            .ok_or_else(|| Error::InvalidUrl(format!("url {} has no port", url)))?;
         let path = url.path();
         Ok((host, port, path))
     }

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,14 +1,14 @@
 use base64;
 use time;
 use url::Url;
-use mac::{Mac, MacType};
-use header::Header;
-use response::ResponseBuilder;
-use bewit::Bewit;
-use credentials::{Credentials, Key};
+use crate::mac::{Mac, MacType};
+use crate::header::Header;
+use crate::response::ResponseBuilder;
+use crate::bewit::Bewit;
+use crate::credentials::{Credentials, Key};
 use rand;
 use rand::Rng;
-use error::*;
+use crate::error::*;
 use time::{now, Duration};
 use std::str;
 
@@ -364,8 +364,8 @@ fn random_string(bytes: usize) -> String {
 mod test {
     use super::*;
     use time::Timespec;
-    use credentials::{Credentials, Key};
-    use header::Header;
+    use crate::credentials::{Credentials, Key};
+    use crate::header::Header;
     use url::Url;
     use ring::digest;
     use std::str::FromStr;

--- a/src/response.rs
+++ b/src/response.rs
@@ -187,12 +187,12 @@ mod test {
     use crate::header::Header;
     use crate::credentials::Key;
     use crate::mac::Mac;
-    use time::Timespec;
+    use std::time::{Duration, UNIX_EPOCH};
     use ring::digest;
 
     fn make_req_header() -> Header {
         Header::new(None,
-                    Some(Timespec::new(1353832234, 0)),
+                    Some(UNIX_EPOCH + Duration::new(1353832234, 0)),
                     Some("j4h3g2"),
                     None,
                     None,

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,7 +1,7 @@
-use mac::{Mac, MacType};
-use header::Header;
-use credentials::Key;
-use error::*;
+use crate::mac::{Mac, MacType};
+use crate::header::Header;
+use crate::credentials::Key;
+use crate::error::*;
 
 /// A Response represents a response from an HTTP server.
 ///
@@ -184,9 +184,9 @@ impl<'a> ResponseBuilder<'a> {
 #[cfg(test)]
 mod test {
     use super::ResponseBuilder;
-    use header::Header;
-    use credentials::Key;
-    use mac::Mac;
+    use crate::header::Header;
+    use crate::credentials::Key;
+    use crate::mac::Mac;
     use time::Timespec;
     use ring::digest;
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -30,11 +30,11 @@ impl<'a> Response<'a> {
         let mac;
         let ts = self.req_header
             .ts
-            .ok_or("Missing `ts` atttribute in Hawk header")?;
+            .ok_or(Error::MissingTs)?;
         let nonce = self.req_header
             .nonce
             .as_ref()
-            .ok_or("Missing `nonce` attribute in Hawk header")?;
+            .ok_or(Error::MissingNonce)?;
         mac = Mac::new(MacType::Response,
                        key,
                        ts,


### PR DESCRIPTION
- Update to Rust 2018 (fixes #17)
- Replace error_chain with failure. (fixes #15)
- Replace `time` (which is deprecated) with `std::time`
- Update other dependency versions.

Also cleaned up error handling some (and header parsing as a result), and did some minor optimizations.

I did this before checking your issue list, sorry for stepping on your toes with #17/#15, I kind of had still been under the assumption that the maintenance on this crate was quite passive.

Caveat: I don't really understand HAWK deeply, so I'm mostly relying on tests to catch mistakes. That said, the changes are almost all mechanical.

Note: this is a breaking change, so you'll want to bump the major version. In practice the breaking changes are that new error kinds were added, and Timespec was replaced with SystemTime.