### PR TITLE
Configurable cryptography

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -12,7 +12,7 @@ tasks:
           - pull_request.synchronize
     payload:
       maxRunTime: 3600
-      image: djmitche/rust-hawk-test:3.0.0@sha256:f7ada4debbf1b6c0dbbb5f5c27783ebdf7660d7714378e78478d27e0489f300e
+      image: djmitche/rust-hawk-test:1.35.0@sha256:b4d60deff348ed8091fd1e431ac7d497aa6881b7fcbee56bf6272cb540f4b35a
       command:
         - /bin/bash
         - '-c'
@@ -21,14 +21,11 @@ tasks:
           cd repo &&
           git config advice.detachedHead false &&
           git checkout {{event.head.sha}} &&
-          echo $PATH &&
-          rustup run stable cargo test &&
-          rustup run stable cargo test --features="use_openssl" --no-default-features &&
-          rustup run nightly cargo clippy -- -D clippy &&
-          rustup run nightly cargo clippy --features="use_openssl" -- -D clippy
+          cargo test --features="use_ring" --no-default-features &&
+          cargo test --features="use_openssl" --no-default-features &&
+          cargo clippy
     metadata:
       name: Tests
-      description: Run `cargo test`
+      description: Run tests
       owner: '{{ event.head.user.email }}'
       source: '{{ event.head.repo.url }}'
-

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -23,8 +23,9 @@ tasks:
           git checkout {{event.head.sha}} &&
           echo $PATH &&
           rustup run stable cargo test &&
-          rustup run nightly cargo test &&
-          rustup run nightly cargo clippy -- -D clippy
+          rustup run stable cargo test --features="use_openssl" --no-default-features &&
+          rustup run nightly cargo clippy -- -D clippy &&
+          rustup run nightly cargo clippy --features="use_openssl" -- -D clippy
     metadata:
       name: Tests
       description: Run `cargo test`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+## Unreleased Changes
+
+- The cryptography library used is now configurable.
+    - By default `ring` is used (the `use_ring` feature).
+    - You can use the `use_openssl` feature to use openssl instead
+        - e.g. in your Cargo.toml:
+        ```toml
+        [dependencies.hawk]
+        version = "..."
+        features = ["use_openssl"]
+        default-features = false
+        ```
+    - You can use neither and provide your own implementation using the functions in
+      `hawk::crypto` if neither feature is enabled.
+    - Note that enabling both `use_ring` and `use_openssl` will cause a build
+      failure.
+
+- BREAKING: Many functions that previously returned `T` now return `hawk::Result<T>`.
+    - Specifically, `PayloadHasher::{hash,update,finish}`, `Key::{new,sign}`.
+
+- BREAKING: `hawk::SHA{256,384,512}` are now `const` `DigestAlgorithm`s and not
+  aliases for `ring::Algorithm`
+
+- BREAKING: `Key::new` now takes a `DigestAlgorithm` and not a
+  `&'static ring::Algorithm`.
+    - If you were passing e.g. `&hawk::SHA256`, you probably just need
+      to pass `hawk::SHA256` now instead.
+
+- BREAKING (though unlikely): `Error::Rng` has been removed, and `Error::Crypto` added
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,13 +9,21 @@ documentation = "https://docs.rs/hawk/"
 homepage = "https://docs.rs/hawk/"
 description = "Hawk Implementation for Rust"
 edition = "2018"
+build = "build.rs"
 
 [dev-dependencies]
 pretty_assertions = "^0.1.2"
 
+[features]
+default = ["use_ring"]
+use_ring = ["ring"]
+use_openssl = ["openssl"]
+
 [dependencies]
 base64 = "0.10.1"
-ring = "0.14.6"
+ring = { version = "0.14.6", optional = true }
+openssl = { version = "0.10.20", optional = true }
 url = "1.7.2"
 rand = "0.6.5"
 failure = { version = "0.1.5", features = ["derive"] }
+once_cell = "0.1.8"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,5 @@
+// Just check that we aren't asked to use an impossible configuration.
+fn main() {
+    assert!(!(cfg!(feature = "use_ring") && cfg!(feature = "use_openssl")),
+            "Cannot configure `hawk` with both `use_ring` and `use_openssl`!");
+}

--- a/docker/rust-hawk-test.sh
+++ b/docker/rust-hawk-test.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-docker build -t djmitche/rust-hawk-test:3.0.0 rust-hawk-test
+docker build -t djmitche/rust-hawk-test:1.34.0 rust-hawk-test

--- a/docker/rust-hawk-test/setup.sh
+++ b/docker/rust-hawk-test/setup.sh
@@ -20,13 +20,11 @@ chmod +x rustup-init
 ./rustup-init -y --no-modify-path
 
 # install stable
-/root/.cargo/bin/rustup install stable
+/root/.cargo/bin/rustup install 1.34.0
+/root/.cargo/bin/rustup component add clippy
+/root/.cargo/bin/rustup component add rustfmt
 
-# install nightly + clippy
-/root/.cargo/bin/rustup install nightly
-/root/.cargo/bin/rustup component add --toolchain nightly clippy-preview
-
-# install node
+# install node (the version is not critical)
 curl https://nodejs.org/dist/v6.11.1/node-v6.11.1-linux-x64.tar.xz | xz -d | tar -C /usr --strip=1 -xf -
 
 # cleanup

--- a/src/bewit.rs
+++ b/src/bewit.rs
@@ -113,12 +113,11 @@ impl<'a> FromStr for Bewit<'a> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, any(feature = "use_ring", feature = "use_openssl")))]
 mod test {
     use super::*;
     use crate::credentials::Key;
     use crate::mac::{Mac, MacType};
-    use ring::digest;
     use std::str::FromStr;
 
     fn make_mac() -> Mac {
@@ -127,8 +126,8 @@ mod test {
                 11u8, 19, 228, 209, 79, 189, 200, 59, 166, 47, 86, 254, 235, 184, 120, 197, 75,
                 152, 201, 79, 115, 61, 111, 242, 219, 187, 173, 14, 227, 108, 60, 232,
             ],
-            &digest::SHA256,
-        );
+            crate::DigestAlgorithm::Sha256,
+        ).unwrap();
         Mac::new(
             MacType::Header,
             &key,

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -1,25 +1,35 @@
-use ring::{digest, hmac};
+use crate::crypto::{self, HmacKey};
+
+#[derive(Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Hash, Debug)]
+pub enum DigestAlgorithm {
+    Sha256,
+    Sha384,
+    Sha512,
+    // Indicate that this isn't an enum that anyone should match on, and that we
+    // reserve the right to add to this enumeration without making a major
+    // version bump. Once https://github.com/rust-lang/rfcs/blob/master/text/2008-non-exhaustive.md
+    // is stabilized, that should be used instead.
+    #[doc(hidden)]
+    _Nonexhaustive,
+}
 
 /// Hawk key.
 ///
 /// While any sequence of bytes can be specified as a key, note that each digest algorithm has
 /// a suggested key length, and that passwords should *not* be used as keys.  Keys of incorrect
 /// length are handled according to the digest's implementation.
-pub struct Key(hmac::SigningKey);
+pub struct Key(Box<dyn HmacKey>);
 
 impl Key {
-    pub fn new<B>(key: B, algorithm: &'static digest::Algorithm) -> Key
+    pub fn new<B>(key: B, algorithm: DigestAlgorithm) -> crate::Result<Key>
     where
         B: AsRef<[u8]>,
     {
-        Key(hmac::SigningKey::new(algorithm, key.as_ref()))
+        Ok(Key(crypto::new_key(algorithm, key.as_ref())?))
     }
 
-    pub fn sign(&self, data: &[u8]) -> Vec<u8> {
-        let digest = hmac::sign(&self.0, data);
-        let mut mac = vec![0; self.0.digest_algorithm().output_len];
-        mac.copy_from_slice(digest.as_ref());
-        mac
+    pub fn sign(&self, data: &[u8]) -> crate::Result<Vec<u8>> {
+        Ok(self.0.sign(data)?)
     }
 }
 
@@ -31,22 +41,21 @@ pub struct Credentials {
     pub key: Key,
 }
 
-#[cfg(test)]
+#[cfg(all(test, any(feature = "use_ring", feature = "use_openssl")))]
 mod test {
     use super::*;
-    use ring::digest;
 
     #[test]
     fn test_new_sha256() {
         let key = vec![77u8; 32];
         // hmac::SigningKey doesn't allow any visibilty inside, so we just build the
         // key and assume it works..
-        Key::new(key, &digest::SHA256);
+        Key::new(key, DigestAlgorithm::Sha256).unwrap();
     }
 
     #[test]
     fn test_new_sha256_bad_length() {
         let key = vec![0u8; 99];
-        Key::new(key, &digest::SHA256);
+        Key::new(key, DigestAlgorithm::Sha256).unwrap();
     }
 }

--- a/src/crypto/holder.rs
+++ b/src/crypto/holder.rs
@@ -1,0 +1,48 @@
+use once_cell::sync::OnceCell;
+use failure::Fail;
+use super::Cryptographer;
+
+static CRYPTOGRAPHER: OnceCell<&'static dyn Cryptographer> = OnceCell::INIT;
+
+#[derive(Debug, Fail)]
+#[fail(display = "Cryptographer already initialized")]
+pub struct SetCryptographerError(());
+
+/// Sets the global object that will be used for cryptographic operations.
+///
+/// This is a convenience wrapper over [`set_cryptographer`],
+/// but takes a `Box<dyn Cryptographer>` instead.
+pub fn set_boxed_cryptographer(c: Box<dyn Cryptographer>) -> Result<(), SetCryptographerError> {
+    set_cryptographer(Box::leak(c))
+}
+
+/// Sets the global object that will be used for cryptographic operations.
+///
+/// This function may only be called once in the lifetime of a program.
+///
+/// Any calls into this crate that perform cryptography prior to calling this
+/// function will panic.
+pub fn set_cryptographer(c: &'static dyn Cryptographer) -> Result<(), SetCryptographerError> {
+    CRYPTOGRAPHER.set(c).map_err(|_| SetCryptographerError(()))
+}
+
+pub(crate) fn get_crypographer() -> &'static dyn Cryptographer {
+    autoinit_crypto();
+    CRYPTOGRAPHER.get().map(|d| *d).expect("`hawk` cryptographer not initialized!")
+}
+
+#[cfg(feature = "use_ring")]
+#[inline]
+fn autoinit_crypto() {
+    let _ = set_cryptographer(&super::ring::RingCryptographer);
+}
+
+#[cfg(feature = "use_openssl")]
+#[inline]
+fn autoinit_crypto() {
+}
+
+#[cfg(not(any(feature = "use_openssl", feature = "use_ring")))]
+#[inline]
+fn autoinit_crypto() {
+}

--- a/src/crypto/holder.rs
+++ b/src/crypto/holder.rs
@@ -12,6 +12,7 @@ pub struct SetCryptographerError(());
 ///
 /// This is a convenience wrapper over [`set_cryptographer`],
 /// but takes a `Box<dyn Cryptographer>` instead.
+#[cfg(not(any(feature = "use_ring", feature = "use_openssl")))]
 pub fn set_boxed_cryptographer(c: Box<dyn Cryptographer>) -> Result<(), SetCryptographerError> {
     set_cryptographer(Box::leak(c))
 }

--- a/src/crypto/holder.rs
+++ b/src/crypto/holder.rs
@@ -14,6 +14,8 @@ pub struct SetCryptographerError(());
 /// but takes a `Box<dyn Cryptographer>` instead.
 #[cfg(not(any(feature = "use_ring", feature = "use_openssl")))]
 pub fn set_boxed_cryptographer(c: Box<dyn Cryptographer>) -> Result<(), SetCryptographerError> {
+    // Just leak the Box. It wouldn't be freed as a `static` anyway, and we
+    // never allow this to be re-assigned (so it's not a meaningful memory leak).
     set_cryptographer(Box::leak(c))
 }
 

--- a/src/crypto/holder.rs
+++ b/src/crypto/holder.rs
@@ -40,6 +40,7 @@ fn autoinit_crypto() {
 #[cfg(feature = "use_openssl")]
 #[inline]
 fn autoinit_crypto() {
+    let _ = set_cryptographer(&super::openssl::OpensslCryptographer);
 }
 
 #[cfg(not(any(feature = "use_openssl", feature = "use_ring")))]

--- a/src/crypto/holder.rs
+++ b/src/crypto/holder.rs
@@ -28,7 +28,7 @@ pub fn set_cryptographer(c: &'static dyn Cryptographer) -> Result<(), SetCryptog
 
 pub(crate) fn get_crypographer() -> &'static dyn Cryptographer {
     autoinit_crypto();
-    CRYPTOGRAPHER.get().map(|d| *d).expect("`hawk` cryptographer not initialized!")
+    *CRYPTOGRAPHER.get().expect("`hawk` cryptographer not initialized!")
 }
 
 #[cfg(feature = "use_ring")]

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -49,12 +49,12 @@ pub trait Cryptographer: Send + Sync + 'static {
 }
 
 /// Type-erased hmac key type.
-pub trait HmacKey {
+pub trait HmacKey: Send + Sync + 'static {
     fn sign(&self, data: &[u8]) -> Result<Vec<u8>, CryptoError>;
 }
 
 /// Type-erased hash context type.
-pub trait Hasher {
+pub trait Hasher: Send + Sync + 'static {
     fn update(&mut self, data: &[u8]) -> Result<(), CryptoError>;
     // Note: this would take by move but that's not object safe :(
     fn finish(&mut self) -> Result<Vec<u8>, CryptoError>;

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -19,6 +19,7 @@ mod ring;
 #[cfg(feature = "use_openssl")]
 mod openssl;
 
+#[cfg(not(any(feature = "use_ring", feature = "use_openssl")))]
 pub use self::holder::{set_cryptographer, set_boxed_cryptographer};
 
 

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -1,0 +1,78 @@
+//! `hawk` must perform certain cryptographic operations in order to function,
+//! and applications may need control over which library is used for these.
+//!
+//! This module can be used for that purpose. If you do not care, this crate can
+//! be configured so that a default implementation is provided based on either
+//! `ring` or `openssl` (via the `use_ring` and `use_openssl` features respectively).
+//!
+//! Should you need something custom, then you can provide it by implementing
+//! [`Cryptographer`] and using the [`set_cryptographer`] or
+//! [`set_boxed_cryptographer`] functions.
+use failure::Fail;
+use crate::DigestAlgorithm;
+
+pub(crate) mod holder;
+pub(crate) use holder::get_crypographer;
+
+#[cfg(feature = "use_ring")]
+mod ring;
+#[cfg(feature = "use_openssl")]
+mod openssl;
+
+pub use self::holder::{set_cryptographer, set_boxed_cryptographer};
+
+
+#[derive(Debug, Fail)]
+pub enum CryptoError {
+
+    /// The configured cryptographer does not support the digest algorithm
+    /// specified. This should only happen for custom `Cryptographer` implementations
+    #[fail(display = "Digest algorithm {:?} is unsupported by this Cryptographer", _0)]
+    UnsupportedDigest(DigestAlgorithm),
+
+    /// The configured cryptographer implementation failed to perform an
+    /// operation in some way.
+    #[fail(display = "{}", _0)]
+    Other(#[fail(cause)] failure::Error),
+}
+
+/// A trait encapsulating the cryptographic operations required by this library.
+///
+/// If you use this library with either the `use_ring` or `use_openssl` features enabled,
+/// then you do not have to worry about this.
+pub trait Cryptographer: Send + Sync + 'static {
+    fn rand_bytes(&self, output: &mut [u8]) -> Result<(), CryptoError>;
+    fn new_key(&self, algorithm: DigestAlgorithm, key: &[u8]) -> Result<Box<dyn HmacKey>, CryptoError>;
+    fn new_hasher(&self, algo: DigestAlgorithm) -> Result<Box<dyn Hasher>, CryptoError>;
+    fn constant_time_compare(&self, a: &[u8], b: &[u8]) -> bool;
+}
+
+/// Type-erased hmac key type.
+pub trait HmacKey {
+    fn sign(&self, data: &[u8]) -> Result<Vec<u8>, CryptoError>;
+}
+
+/// Type-erased hash context type.
+pub trait Hasher {
+    fn update(&mut self, data: &[u8]) -> Result<(), CryptoError>;
+    // Note: this would take by move but that's not object safe :(
+    fn finish(&mut self) -> Result<Vec<u8>, CryptoError>;
+}
+
+// For convenience
+
+pub(crate) fn rand_bytes(buffer: &mut [u8]) -> Result<(), CryptoError> {
+    get_crypographer().rand_bytes(buffer)
+}
+
+pub(crate) fn new_key(algorithm: DigestAlgorithm, key: &[u8]) -> Result<Box<dyn HmacKey>, CryptoError> {
+    get_crypographer().new_key(algorithm, key)
+}
+
+pub(crate) fn constant_time_compare(a: &[u8], b: &[u8]) -> bool {
+    get_crypographer().constant_time_compare(a, b)
+}
+
+pub(crate) fn new_hasher(algorithm: DigestAlgorithm) -> Result<Box<dyn Hasher>, CryptoError> {
+    Ok(get_crypographer().new_hasher(algorithm)?)
+}

--- a/src/crypto/openssl.rs
+++ b/src/crypto/openssl.rs
@@ -1,0 +1,93 @@
+use super::{Cryptographer, Hasher, HmacKey, CryptoError};
+use crate::DigestAlgorithm;
+use std::convert::{TryFrom, TryInto};
+
+use openssl::hash::MessageDigest;
+use openssl::pkey::{PKey, Private};
+use openssl::sign::Signer;
+use openssl::error::ErrorStack;
+
+impl From<ErrorStack> for CryptoError {
+    fn from(e: ErrorStack) -> Self {
+        CryptoError::Other(e.into())
+    }
+}
+
+pub struct OpensslCryptographer;
+
+struct OpensslHmacKey {
+    key: PKey<Private>,
+    digest: MessageDigest,
+}
+
+impl HmacKey for OpensslHmacKey {
+    fn sign(&self, data: &[u8]) -> Result<Vec<u8>, CryptoError> {
+        let mut hmac_signer = Signer::new(self.digest.clone(), &self.key)?;
+        hmac_signer.update(&data)?;
+        let digest = hmac_signer.sign_to_vec()?;
+        let mut mac = vec![0; self.digest.size()];
+        mac.clone_from_slice(digest.as_ref());
+        Ok(mac)
+    }
+}
+
+// This is always `Some` until `finish` is called.
+struct OpensslHasher(Option<openssl::hash::Hasher>);
+
+impl Hasher for OpensslHasher {
+    fn update(&mut self, data: &[u8]) -> Result<(), CryptoError> {
+        self.0.as_mut().expect("update called after `finish`").update(data)?;
+        Ok(())
+    }
+
+    fn finish(&mut self) -> Result<Vec<u8>, CryptoError> {
+        let digest = self.0.take().expect("`finish` called twice").finish()?;
+        let bytes: &[u8] = digest.as_ref();
+        Ok(bytes.to_owned())
+    }
+}
+
+
+impl Cryptographer for OpensslCryptographer {
+    fn rand_bytes(&self, output: &mut [u8]) -> Result<(), CryptoError> {
+        openssl::rand::rand_bytes(output)?;
+        Ok(())
+    }
+
+    fn new_key(&self, algorithm: DigestAlgorithm, key: &[u8]) -> Result<Box<dyn HmacKey>, CryptoError> {
+        let digest = algorithm.try_into()?;
+        Ok(Box::new(OpensslHmacKey {
+            key: PKey::hmac(key)?,
+            digest,
+        }))
+    }
+
+    fn constant_time_compare(&self, a: &[u8], b: &[u8]) -> bool {
+        // openssl::memcmp::eq panics if the lengths are not the same. ring
+        // returns `Err` (and notes in the docs that it is not constant time if
+        // the lengths are not the same). We make this behave like ring.
+        if a.len() != b.len() {
+            false
+        } else {
+            openssl::memcmp::eq(a, b)
+        }
+    }
+
+    fn new_hasher(&self, algorithm: DigestAlgorithm) -> Result<Box<dyn Hasher>, CryptoError> {
+        let ctx = openssl::hash::Hasher::new(algorithm.try_into()?)?;
+        Ok(Box::new(OpensslHasher(Some(ctx))))
+    }
+}
+
+impl TryFrom<DigestAlgorithm> for MessageDigest {
+    type Error = CryptoError;
+    fn try_from(algorithm: DigestAlgorithm) -> Result<Self, CryptoError> {
+        match algorithm {
+            DigestAlgorithm::Sha256 => Ok(MessageDigest::sha256()),
+            DigestAlgorithm::Sha384 => Ok(MessageDigest::sha384()),
+            DigestAlgorithm::Sha512 => Ok(MessageDigest::sha512()),
+            algo => Err(CryptoError::UnsupportedDigest(algo)),
+        }
+    }
+}
+

--- a/src/crypto/openssl.rs
+++ b/src/crypto/openssl.rs
@@ -22,7 +22,7 @@ struct OpensslHmacKey {
 
 impl HmacKey for OpensslHmacKey {
     fn sign(&self, data: &[u8]) -> Result<Vec<u8>, CryptoError> {
-        let mut hmac_signer = Signer::new(self.digest.clone(), &self.key)?;
+        let mut hmac_signer = Signer::new(self.digest, &self.key)?;
         hmac_signer.update(&data)?;
         let digest = hmac_signer.sign_to_vec()?;
         let mut mac = vec![0; self.digest.size()];

--- a/src/crypto/ring.rs
+++ b/src/crypto/ring.rs
@@ -1,0 +1,76 @@
+use super::{Cryptographer, Hasher, HmacKey, CryptoError};
+use ring::{digest, hmac};
+use crate::DigestAlgorithm;
+use std::convert::{TryFrom, TryInto};
+use failure::err_msg;
+
+impl From<ring::error::Unspecified> for CryptoError {
+    // Ring's errors are entirely opaque
+    fn from(_: ring::error::Unspecified) -> Self {
+        CryptoError::Other(err_msg("Unspecified ring error"))
+    }
+}
+
+pub struct RingCryptographer;
+
+struct RingHmacKey(hmac::SigningKey);
+
+impl HmacKey for RingHmacKey {
+    fn sign(&self, data: &[u8]) -> Result<Vec<u8>, CryptoError> {
+        let digest = hmac::sign(&self.0, data);
+        let mut mac = vec![0; self.0.digest_algorithm().output_len];
+        mac.copy_from_slice(digest.as_ref());
+        Ok(mac)
+    }
+}
+// This is always `Some` until `finish` is called.
+struct RingHasher(Option<digest::Context>);
+
+impl Hasher for RingHasher {
+    fn update(&mut self, data: &[u8]) -> Result<(), CryptoError> {
+        self.0.as_mut().expect("update called after `finish`").update(data);
+        Ok(())
+    }
+
+    fn finish(&mut self) -> Result<Vec<u8>, CryptoError> {
+        let digest = self.0.take().expect("`finish` called twice").finish();
+        let bytes: &[u8] = digest.as_ref();
+        Ok(bytes.to_owned())
+    }
+}
+
+
+impl Cryptographer for RingCryptographer {
+    fn rand_bytes(&self, output: &mut [u8]) -> Result<(), CryptoError> {
+        use ring::rand::SecureRandom;
+        ring::rand::SystemRandom.fill(output)?;
+        Ok(())
+    }
+
+    fn new_key(&self, algorithm: DigestAlgorithm, key: &[u8]) -> Result<Box<dyn HmacKey>, CryptoError> {
+        let k = hmac::SigningKey::new(algorithm.try_into()?, key);
+        Ok(Box::new(RingHmacKey(k)))
+    }
+
+    fn constant_time_compare(&self, a: &[u8], b: &[u8]) -> bool {
+        ring::constant_time::verify_slices_are_equal(a, b).is_ok()
+    }
+
+    fn new_hasher(&self, algorithm: DigestAlgorithm) -> Result<Box<dyn Hasher>, CryptoError> {
+        let ctx = digest::Context::new(algorithm.try_into()?);
+        Ok(Box::new(RingHasher(Some(ctx))))
+    }
+}
+
+impl TryFrom<DigestAlgorithm> for &'static digest::Algorithm {
+    type Error = CryptoError;
+    fn try_from(algorithm: DigestAlgorithm) -> Result<Self, CryptoError> {
+        match algorithm {
+            DigestAlgorithm::Sha256 => Ok(&digest::SHA256),
+            DigestAlgorithm::Sha384 => Ok(&digest::SHA384),
+            DigestAlgorithm::Sha512 => Ok(&digest::SHA512),
+            algo => Err(CryptoError::UnsupportedDigest(algo)),
+        }
+    }
+}
+

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,5 @@
 use failure::Fail;
+use crate::crypto::CryptoError;
 
 pub type Result<T> = std::result::Result<T, Error>;
 
@@ -25,8 +26,8 @@ pub enum Error {
     #[fail(display = "Base64 Decode error: {}", _0)]
     Decode(#[fail(cause)] base64::DecodeError),
 
-    #[fail(display = "RNG error: {}", _0)]
-    Rng(#[fail(cause)] rand::Error),
+    #[fail(display = "Crypto error: {}", _0)]
+    Crypto(#[fail(cause)] CryptoError),
 }
 
 #[derive(Fail, Debug, PartialEq)]
@@ -55,9 +56,9 @@ impl From<std::io::Error> for Error {
     }
 }
 
-impl From<rand::Error> for Error {
-    fn from(e: rand::Error) -> Self {
-        Error::Rng(e)
+impl From<CryptoError> for Error {
+    fn from(e: CryptoError) -> Self {
+        Error::Crypto(e)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,10 +17,10 @@
 //!     // provide the Hawk id and key
 //!     let credentials = Credentials {
 //!         id: "test-client".to_string(),
-//!         key: Key::new(vec![99u8; 32], &SHA256),
+//!         key: Key::new(vec![99u8; 32], SHA256).unwrap(),
 //!     };
 //!
-//!     let payload_hash = PayloadHasher::hash("text/plain", &SHA256, "request-body");
+//!     let payload_hash = PayloadHasher::hash("text/plain", SHA256, "request-body").unwrap();
 //!
 //!     // provide the details of the request to be authorized
 //!      let request = RequestBuilder::new("POST", "example.com", 80, "/v1/users")
@@ -68,7 +68,7 @@
 //!        .hash(&hash[..])
 //!        .request();
 //!
-//!    let key = Key::new(vec![99u8; 32], &SHA256);
+//!    let key = Key::new(vec![99u8; 32], SHA256).unwrap();
 //!    let one_week_in_secs = 7 * 24 * 60 * 60;
 //!    if !request.validate_header(&hdr, &key, Duration::from_secs(5200 * one_week_in_secs)) {
 //!        panic!("header validation failed. Is it 2117 already?");
@@ -83,7 +83,7 @@ mod header;
 pub use crate::header::Header;
 
 mod credentials;
-pub use crate::credentials::{Credentials, Key};
+pub use crate::credentials::{Credentials, Key, DigestAlgorithm};
 
 mod request;
 pub use crate::request::{Request, RequestBuilder};
@@ -102,5 +102,8 @@ pub use crate::bewit::Bewit;
 
 pub mod mac;
 
-// convenience imports
-pub use ring::digest::{SHA256, SHA384, SHA512};
+pub mod crypto;
+
+pub const SHA256: DigestAlgorithm = DigestAlgorithm::Sha256;
+pub const SHA384: DigestAlgorithm = DigestAlgorithm::Sha384;
+pub const SHA512: DigestAlgorithm = DigestAlgorithm::Sha512;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,21 @@
 //!        panic!("header validation failed. Is it 2117 already?");
 //!    }
 //! }
-
+//!
+//! ## Features
+//!
+//! By default, the `use_ring` feature is enabled, which means that this crate will
+//! use `ring` for all cryptographic operations.
+//!
+//! Alternatively, one can configure the crate with the `use_openssl`
+//! feature to use the `openssl` crate.
+//!
+//! If no features are enabled, you must provide a custom implementation of the
+//! [`hawk::crypto::Cryptographer`] trait to the `set_cryptographer` function, or
+//! the cryptographic operations will panic.
+//!
+//! Attempting to configure both the `use_ring` and `use_openssl` features will
+//! result in a build error.
 #[cfg(test)]
 #[macro_use]
 extern crate pretty_assertions;

--- a/src/mac.rs
+++ b/src/mac.rs
@@ -41,7 +41,7 @@ impl Mac {
             6 + 1 + // Longer than 6 bytes of port seems very unlikely
             path.len() + 1 +
             hash.map_or(0, |h| h.len() * 4 / 3) + 1 +
-            ext.map_or(0, |e| e.len()) + 1,
+            ext.map_or(0, str::len) + 1,
         );
 
         writeln!(

--- a/src/mac.rs
+++ b/src/mac.rs
@@ -1,7 +1,6 @@
 use crate::credentials::Key;
 use crate::error::*;
 use base64::{display::Base64Display, STANDARD};
-use ring::constant_time;
 use std::io::Write;
 use std::ops::Deref;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -68,7 +67,7 @@ impl Mac {
         }
         writeln!(buffer, "{}", ext.unwrap_or_default())?;
 
-        Ok(Mac(key.sign(buffer.as_ref())))
+        Ok(Mac(key.sign(buffer.as_ref())?))
     }
 }
 
@@ -94,15 +93,14 @@ impl Deref for Mac {
 
 impl PartialEq for Mac {
     fn eq(&self, other: &Mac) -> bool {
-        constant_time::verify_slices_are_equal(&self.0[..], &other.0[..]).is_ok()
+        crate::crypto::constant_time_compare(&self.0, &other.0)
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, any(feature = "use_ring", feature = "use_openssl")))]
 mod test {
     use super::{Mac, MacType};
     use crate::credentials::Key;
-    use ring::digest;
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
     fn key() -> Key {
@@ -111,8 +109,8 @@ mod test {
                 11u8, 19, 228, 209, 79, 189, 200, 59, 166, 47, 86, 254, 235, 184, 120, 197, 75,
                 152, 201, 79, 115, 61, 111, 242, 219, 187, 173, 14, 227, 108, 60, 232,
             ],
-            &digest::SHA256,
-        )
+            crate::SHA256,
+        ).unwrap()
     }
 
     fn sys_time(secs: u64, ns: u32) -> SystemTime {

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -1,85 +1,76 @@
-use ring::digest;
-
+use crate::{crypto, DigestAlgorithm};
+use crate::error::*;
 /// A utility for hashing payloads. Feed your entity body to this, then pass the `finish`
 /// result to a request or response.
-pub struct PayloadHasher {
-    context: digest::Context,
-    algorithm: &'static digest::Algorithm,
-}
+pub struct PayloadHasher(Box<dyn crypto::Hasher>);
 
 impl PayloadHasher {
     /// Create a new PayloadHasher. The `content_type` should be lower-case and should
     /// not include parameters. The digest is assumed to be the same as the digest used
     /// for the credentials in the request.
-    pub fn new<B>(content_type: B, algorithm: &'static digest::Algorithm) -> Self
+    pub fn new<B>(content_type: B, algorithm: DigestAlgorithm) -> Result<Self>
     where
         B: AsRef<[u8]>,
     {
-        let mut hasher = PayloadHasher {
-            context: digest::Context::new(algorithm),
-            algorithm,
-        };
-        hasher.update(b"hawk.1.payload\n");
-        hasher.update(content_type.as_ref());
-        hasher.update(b"\n");
-        hasher
+        let mut hasher = PayloadHasher(crypto::new_hasher(algorithm)?);
+        hasher.update(b"hawk.1.payload\n")?;
+        hasher.update(content_type.as_ref())?;
+        hasher.update(b"\n")?;
+        Ok(hasher)
     }
 
     /// Hash a single value and return it
     pub fn hash<B1, B2>(
         content_type: B1,
-        algorithm: &'static digest::Algorithm,
+        algorithm: DigestAlgorithm,
         payload: B2,
-    ) -> Vec<u8>
+    ) -> Result<Vec<u8>>
     where
         B1: AsRef<[u8]>,
         B2: AsRef<[u8]>,
     {
-        let mut hasher = PayloadHasher::new(content_type, algorithm);
-        hasher.update(payload);
+        let mut hasher = PayloadHasher::new(content_type, algorithm)?;
+        hasher.update(payload)?;
         hasher.finish()
     }
 
     /// Update the hash with new data.
-    pub fn update<B>(&mut self, data: B)
+    pub fn update<B>(&mut self, data: B) -> Result<()>
     where
         B: AsRef<[u8]>,
     {
-        self.context.update(data.as_ref());
+        self.0.update(data.as_ref())?;
+        Ok(())
     }
 
     /// Finish hashing and return the result
     ///
     /// Note that this appends a newline to the payload, as does the JS Hawk implementaiton.
-    pub fn finish(mut self) -> Vec<u8> {
-        self.update(b"\n");
-        let digest = self.context.finish();
-        let mut rv = vec![0; self.algorithm.output_len];
-        rv.clone_from_slice(digest.as_ref());
-        rv
+    pub fn finish(mut self) -> Result<Vec<u8>> {
+        self.update(b"\n")?;
+        Ok(self.0.finish()?)
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, any(feature = "use_ring", feature = "use_openssl")))]
 mod tests {
     use super::PayloadHasher;
-    use ring::digest::SHA256;
 
     #[test]
-    fn hash_consistency() {
-        let mut hasher1 = PayloadHasher::new("text/plain", &SHA256);
-        hasher1.update("pày");
-        hasher1.update("load");
-        let hash1 = hasher1.finish();
+    fn hash_consistency() -> super::Result<()> {
+        let mut hasher1 = PayloadHasher::new("text/plain", crate::SHA256)?;
+        hasher1.update("pày")?;
+        hasher1.update("load")?;
+        let hash1 = hasher1.finish()?;
 
-        let mut hasher2 = PayloadHasher::new("text/plain", &SHA256);
-        hasher2.update("pàyload");
-        let hash2 = hasher2.finish();
+        let mut hasher2 = PayloadHasher::new("text/plain", crate::SHA256)?;
+        hasher2.update("pàyload")?;
+        let hash2 = hasher2.finish()?;
 
-        let hash3 = PayloadHasher::hash("text/plain", &SHA256, "pàyload");
+        let hash3 = PayloadHasher::hash("text/plain", crate::SHA256, "pàyload")?;
 
         let hash4 = // "pàyload" as utf-8 bytes
-            PayloadHasher::hash("text/plain", &SHA256, vec![112, 195, 160, 121, 108, 111, 97, 100]);
+            PayloadHasher::hash("text/plain", crate::SHA256, vec![112, 195, 160, 121, 108, 111, 97, 100])?;
 
         assert_eq!(
             hash1,
@@ -91,5 +82,6 @@ mod tests {
         assert_eq!(hash2, hash1);
         assert_eq!(hash3, hash1);
         assert_eq!(hash4, hash1);
+        Ok(())
     }
 }

--- a/src/response.rs
+++ b/src/response.rs
@@ -183,13 +183,12 @@ impl<'a> ResponseBuilder<'a> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, any(feature = "use_ring", feature = "use_openssl")))]
 mod test {
     use super::ResponseBuilder;
     use crate::credentials::Key;
     use crate::header::Header;
     use crate::mac::Mac;
-    use ring::digest;
     use std::time::{Duration, UNIX_EPOCH};
 
     fn make_req_header() -> Header {
@@ -227,7 +226,7 @@ mod test {
             None,
         )
         .unwrap();
-        assert!(resp.validate_header(&server_header, &Key::new("tok", &digest::SHA256)));
+        assert!(resp.validate_header(&server_header, &Key::new("tok", crate::SHA256).unwrap()));
     }
 
     #[test]
@@ -253,7 +252,7 @@ mod test {
             None,
         )
         .unwrap();
-        assert!(resp.validate_header(&server_header, &Key::new("tok", &digest::SHA256)));
+        assert!(resp.validate_header(&server_header, &Key::new("tok", crate::SHA256).unwrap()));
     }
 
     #[test]
@@ -280,7 +279,7 @@ mod test {
             None,
         )
         .unwrap();
-        assert!(!resp.validate_header(&server_header, &Key::new("tok", &digest::SHA256)));
+        assert!(!resp.validate_header(&server_header, &Key::new("tok", crate::SHA256).unwrap()));
     }
 
     #[test]
@@ -308,7 +307,7 @@ mod test {
             None,
         )
         .unwrap();
-        assert!(resp.validate_header(&server_header, &Key::new("tok", &digest::SHA256)));
+        assert!(resp.validate_header(&server_header, &Key::new("tok", crate::SHA256).unwrap()));
 
         // a different supplied hash won't match..
         let hash = vec![99, 99, 99, 99];
@@ -316,6 +315,6 @@ mod test {
             ResponseBuilder::from_request_header(&req_header, "POST", "localhost", 9988, "/a/b")
                 .hash(&hash[..])
                 .response();
-        assert!(!resp.validate_header(&server_header, &Key::new("tok", &digest::SHA256)));
+        assert!(!resp.validate_header(&server_header, &Key::new("tok", crate::SHA256).unwrap()));
     }
 }


### PR DESCRIPTION
By default it has the `use_ring` feature enabled, and uses ring. Someone who wants to use openssl can turn on the `use_openssl` feature, and someone who wants neither (e.g. mozilla/application-services) can turn off both and provide a custom impl with set_cryptographer.

Since there's nothing sane we can do if both features are on, we detect it and give a explicit error message in a build.rs.

Annoyingly, this means testing / linting both requires

```
cargo test
cargo test --no-default-features --features 'use_openssl'
```

Cargo doesn't really support mutually exclusive features well.

Note: this needs the latest stable version of Rust to compile (e.g. the one that came out yesterday). I don't know if anything needs to change in the tc config for that to work.

Supports https://github.com/mozilla/application-services/issues/959, assuming @eoger thinks we can shoehorn what we need into the trait I've defined there.

There's probably a way this could have less overhead in the ring/openssl cases, but it would be harder to test, so I didn't go with that. As it is, the dynamic machinery is used every time.