### PR TITLE
Extract bewits in RequestBuilder

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,11 +115,12 @@
 //!     .unwrap();
 //! let request_path = format!("/resource?bewit={}", client_bewit.to_str());
 //!
-//! let bldr = RequestBuilder::new("GET", "mysite.com", 443, &request_path);
-//! let (bldr, maybe_bewit) = bldr.extract_bewit().unwrap();
+//! let mut maybe_bewit = None;
+//! let server_req = RequestBuilder::new("GET", "mysite.com", 443, &request_path)
+//!     .extract_bewit(&mut maybe_bewit).unwrap()
+//!     .request();
 //! let bewit = maybe_bewit.unwrap();
 //! assert_eq!(bewit.id(), "me");
-//! let server_req = bldr.request();
 //! assert!(server_req.validate_bewit(&bewit, &credentials.key));
 //! ```
 //!
@@ -146,7 +147,7 @@ mod header;
 pub use crate::header::Header;
 
 mod credentials;
-pub use crate::credentials::{Credentials, Key, DigestAlgorithm};
+pub use crate::credentials::{Credentials, DigestAlgorithm, Key};
 
 mod request;
 pub use crate::request::{Request, RequestBuilder};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,11 +115,11 @@
 //!     .unwrap();
 //! let request_path = format!("/resource?bewit={}", client_bewit.to_str());
 //!
-//! let mut path = Cow::Owned(request_path);
-//! let maybe_bewit = Bewit::from_path(&mut path).expect("bewit parsing failed");
-//! let server_req = RequestBuilder::new("GET", "mysite.com", 443, path.as_ref()).request();
-//! let bewit = maybe_bewit.expect("no bewit in request_path");
+//! let bldr = RequestBuilder::new("GET", "mysite.com", 443, &request_path);
+//! let (bldr, maybe_bewit) = bldr.extract_bewit().unwrap();
+//! let bewit = maybe_bewit.unwrap();
 //! assert_eq!(bewit.id(), "me");
+//! let server_req = bldr.request();
 //! assert!(server_req.validate_bewit(&bewit, &credentials.key));
 //! ```
 //!


### PR DESCRIPTION
Rather than do string manipulation in the Bewit implementation, allow
extracting a Bewit from request metadata while building the Request
object.  The result is a Request with a properly-formed `path` (that is,
without the `bewit=..`) and a Bewit for the caller to validate.

This is a breaking API change to the previous Bewit implementation,
since it drops the `from_path` method, but that implementation has not
been released.