### PR TITLE
[BREAKING] Make signing requests more ergonomic

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -21,6 +21,7 @@ tasks:
           cd repo &&
           git config advice.detachedHead false &&
           git checkout {{event.head.sha}} &&
+          ( cd tests/node; npm install ) &&
           cargo test --features="use_ring" --no-default-features &&
           cargo test --features="use_openssl" --no-default-features &&
           cargo fmt -- --check &&

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ build = "build.rs"
 
 [dev-dependencies]
 pretty_assertions = "^0.6.1"
+futures = "0.1.14"
+tokio = "0.1"
+hyper = "^0.12"
 
 [features]
 default = ["use_ring"]
@@ -27,3 +30,4 @@ url = "2.0.0"
 rand = "0.7.0"
 failure = { version = "0.1.5", features = ["derive"] }
 once_cell = "1.0.1"
+http = "0.1.17"

--- a/src/error.rs
+++ b/src/error.rs
@@ -23,6 +23,9 @@ pub enum Error {
     #[fail(display = "{}", _0)]
     Io(#[fail(cause)] std::io::Error),
 
+    #[fail(display = "{}", _0)]
+    Http(#[fail(cause)] http::Error),
+
     #[fail(display = "Base64 Decode error: {}", _0)]
     Decode(#[fail(cause)] base64::DecodeError),
 
@@ -55,6 +58,12 @@ impl From<base64::DecodeError> for Error {
 impl From<std::io::Error> for Error {
     fn from(e: std::io::Error) -> Self {
         Error::Io(e)
+    }
+}
+
+impl From<http::Error> for Error {
+    fn from(e: http::Error) -> Self {
+        Error::Http(e)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@
 //!
 //!     // provide the details of the request to be authorized
 //!      let request = RequestBuilder::new("POST", "example.com", 80, "/v1/users")
-//!         .hash(&payload_hash[..])
+//!         .hash(payload_hash)
 //!         .request();
 //!
 //!     // Get the resulting header, including the calculated MAC; this involves a random
@@ -85,7 +85,7 @@
 //!    // build a request object based on what we know
 //!    let hash = vec![1, 2, 3, 4];
 //!    let request = RequestBuilder::new("GET", "localhost", 443, "/resource")
-//!        .hash(&hash[..])
+//!        .hash(hash)
 //!        .request();
 //!
 //!    let key = Key::new(vec![99u8; 32], SHA256).unwrap();
@@ -150,7 +150,7 @@ mod credentials;
 pub use crate::credentials::{Credentials, DigestAlgorithm, Key};
 
 mod request;
-pub use crate::request::{Request, RequestBuilder};
+pub use crate::request::{Request, RequestBuilder, RequestState};
 
 mod response;
 pub use crate::response::{Response, ResponseBuilder};
@@ -163,6 +163,9 @@ pub use crate::payload::PayloadHasher;
 
 mod bewit;
 pub use crate::bewit::Bewit;
+
+mod sign;
+pub use crate::sign::SignRequest;
 
 pub mod mac;
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -2,6 +2,7 @@ use crate::credentials::Key;
 use crate::error::*;
 use crate::header::Header;
 use crate::mac::{Mac, MacType};
+use crate::RequestState;
 
 /// A Response represents a response from an HTTP server.
 ///
@@ -19,8 +20,8 @@ pub struct Response<'a> {
     host: &'a str,
     port: u16,
     path: &'a str,
-    req_header: &'a Header,
-    hash: Option<&'a [u8]>,
+    reqstate: &'a RequestState,
+    hash: Option<Vec<u8>>,
     ext: Option<&'a str>,
 }
 
@@ -28,18 +29,19 @@ impl<'a> Response<'a> {
     /// Create a new Header for this response, based on the given request and request header
     pub fn make_header(&self, key: &Key) -> Result<Header> {
         let mac;
-        let ts = self.req_header.ts.ok_or(Error::MissingTs)?;
-        let nonce = self.req_header.nonce.as_ref().ok_or(Error::MissingNonce)?;
         mac = Mac::new(
             MacType::Response,
             key,
-            ts,
-            nonce,
+            self.reqstate.ts,
+            &self.reqstate.nonce,
             self.method,
             self.host,
             self.port,
             self.path,
-            self.hash,
+            match self.hash {
+                Some(ref v) => Some(v),
+                None => None,
+            },
             self.ext,
         )?;
 
@@ -55,7 +57,7 @@ impl<'a> Response<'a> {
             },
             match self.hash {
                 None => None,
-                Some(v) => Some(v.to_vec()),
+                Some(ref h) => Some(h.clone()),
             },
             None,
             None,
@@ -68,18 +70,8 @@ impl<'a> Response<'a> {
     /// checks that one was provided from the server and that it, too, matches.
     pub fn validate_header(&self, response_header: &Header, key: &Key) -> bool {
         // extract required fields, returning early if they are not present
-        let ts = match self.req_header.ts {
-            Some(ts) => ts,
-            None => {
-                return false;
-            }
-        };
-        let nonce = match self.req_header.nonce {
-            Some(ref nonce) => nonce,
-            None => {
-                return false;
-            }
-        };
+        let ts = self.reqstate.ts;
+        let nonce = &self.reqstate.nonce;
         let header_mac = match response_header.mac {
             Some(ref mac) => mac,
             None => {
@@ -119,8 +111,8 @@ impl<'a> Response<'a> {
         };
 
         // ..then the hashes
-        if let Some(local_hash) = self.hash {
-            if let Some(server_hash) = header_hash {
+        if let Some(ref local_hash) = self.hash {
+            if let Some(ref server_hash) = response_header.hash {
                 if local_hash != server_hash {
                     return false;
                 }
@@ -129,7 +121,7 @@ impl<'a> Response<'a> {
             }
         }
 
-        // NOTE: the timestamp self.req_header.ts was generated locally, so
+        // NOTE: the timestamp self.reqstate.ts was generated locally, so
         // there is no need to verify it
 
         true
@@ -143,8 +135,8 @@ impl<'a> ResponseBuilder<'a> {
     /// Generate a new Response from a request header.
     ///
     /// This is more commonly accessed through `Request::make_response`.
-    pub fn from_request_header(
-        req_header: &'a Header,
+    pub fn from_request_state(
+        reqstate: &'a RequestState,
         method: &'a str,
         host: &'a str,
         port: u16,
@@ -155,7 +147,7 @@ impl<'a> ResponseBuilder<'a> {
             host,
             port,
             path,
-            req_header,
+            reqstate,
             hash: None,
             ext: None,
         })
@@ -164,7 +156,7 @@ impl<'a> ResponseBuilder<'a> {
     /// Set the content hash for the response.
     ///
     /// This should always be calculated from the response payload, not copied from a header.
-    pub fn hash<H: Into<Option<&'a [u8]>>>(mut self, hash: H) -> Self {
+    pub fn hash<H: Into<Option<Vec<u8>>>>(mut self, hash: H) -> Self {
         self.0.hash = hash.into();
         self
     }
@@ -189,27 +181,21 @@ mod test {
     use crate::credentials::Key;
     use crate::header::Header;
     use crate::mac::Mac;
+    use crate::RequestState;
     use std::time::{Duration, UNIX_EPOCH};
 
-    fn make_req_header() -> Header {
-        Header::new(
-            None,
-            Some(UNIX_EPOCH + Duration::new(1353832234, 0)),
-            Some("j4h3g2"),
-            None,
-            None,
-            None,
-            None,
-            None,
-        )
-        .unwrap()
+    fn make_reqstate() -> RequestState {
+        RequestState {
+            ts: UNIX_EPOCH + Duration::new(1353832234, 0),
+            nonce: "j4h3g2".to_string(),
+        }
     }
 
     #[test]
     fn test_validation_no_hash() {
-        let req_header = make_req_header();
+        let reqstate = make_reqstate();
         let resp =
-            ResponseBuilder::from_request_header(&req_header, "POST", "localhost", 9988, "/a/b")
+            ResponseBuilder::from_request_state(&reqstate, "POST", "localhost", 9988, "/a/b")
                 .response();
         let mac: Mac = Mac::from(vec![
             48, 133, 228, 163, 224, 197, 222, 77, 117, 81, 143, 73, 71, 120, 68, 238, 228, 40, 55,
@@ -233,9 +219,9 @@ mod test {
     fn test_validation_hash_in_header() {
         // When a hash is provided in the response header, but no hash is added to the Response,
         // it is ignored (so validation succeeds)
-        let req_header = make_req_header();
+        let reqstate = make_reqstate();
         let resp =
-            ResponseBuilder::from_request_header(&req_header, "POST", "localhost", 9988, "/a/b")
+            ResponseBuilder::from_request_state(&reqstate, "POST", "localhost", 9988, "/a/b")
                 .response();
         let mac: Mac = Mac::from(vec![
             33, 147, 159, 211, 184, 194, 189, 74, 53, 229, 241, 161, 215, 145, 22, 34, 206, 207,
@@ -258,11 +244,11 @@ mod test {
     #[test]
     fn test_validation_hash_required_but_not_given() {
         // When Response.hash is called, but no hash is in the hader, validation fails.
-        let req_header = make_req_header();
+        let reqstate = make_reqstate();
         let hash = vec![1, 2, 3, 4];
         let resp =
-            ResponseBuilder::from_request_header(&req_header, "POST", "localhost", 9988, "/a/b")
-                .hash(&hash[..])
+            ResponseBuilder::from_request_state(&reqstate, "POST", "localhost", 9988, "/a/b")
+                .hash(hash)
                 .response();
         let mac: Mac = Mac::from(vec![
             48, 133, 228, 163, 224, 197, 222, 77, 117, 81, 143, 73, 71, 120, 68, 238, 228, 40, 55,
@@ -286,11 +272,11 @@ mod test {
     fn test_validation_hash_validated() {
         // When a hash is provided in the response header and the Response.hash method is called,
         // the two must match
-        let req_header = make_req_header();
+        let reqstate = make_reqstate();
         let hash = vec![1, 2, 3, 4];
         let resp =
-            ResponseBuilder::from_request_header(&req_header, "POST", "localhost", 9988, "/a/b")
-                .hash(&hash[..])
+            ResponseBuilder::from_request_state(&reqstate, "POST", "localhost", 9988, "/a/b")
+                .hash(hash)
                 .response();
         let mac: Mac = Mac::from(vec![
             33, 147, 159, 211, 184, 194, 189, 74, 53, 229, 241, 161, 215, 145, 22, 34, 206, 207,
@@ -312,8 +298,8 @@ mod test {
         // a different supplied hash won't match..
         let hash = vec![99, 99, 99, 99];
         let resp =
-            ResponseBuilder::from_request_header(&req_header, "POST", "localhost", 9988, "/a/b")
-                .hash(&hash[..])
+            ResponseBuilder::from_request_state(&reqstate, "POST", "localhost", 9988, "/a/b")
+                .hash(hash)
                 .response();
         assert!(!resp.validate_header(&server_header, &Key::new("tok", crate::SHA256).unwrap()));
     }

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -1,0 +1,39 @@
+use crate::{Credentials, RequestBuilder, RequestState};
+use http;
+
+pub trait SignRequest {
+    /// Sign a request using the given credentials.  The `build` callable can add any additional
+    /// desired attributes to the hawk::RequestBuilder, such as `ext` or a hash.
+    fn sign_hawk<F>(&mut self, credentials: &Credentials, rs: &RequestState, build: F) -> &mut Self
+    where
+        F: FnOnce(RequestBuilder) -> RequestBuilder;
+}
+
+// TODO: find some way to output a ResponseBuilder here, too; maybe stick it in RequestState?
+// TODO: SignRequestRequest
+impl SignRequest for http::request::Builder {
+    fn sign_hawk<F>(&mut self, credentials: &Credentials, rs: &RequestState, build: F) -> &mut Self
+    where
+        F: FnOnce(RequestBuilder) -> RequestBuilder,
+    {
+        let method = self
+            .method_ref()
+            .expect("request does not have a method")
+            .as_str();
+        let uri = self.uri_ref().expect("request does not have uri");
+        let host = uri.host().expect("request uri does not have a host");
+        let port = uri.port_u16().expect("request uri does not have a port");
+        let path = uri
+            .path_and_query()
+            .expect("request uri does not have a path")
+            .as_str();
+
+        let bldr = build(RequestBuilder::new(method, host, port, path));
+        let req_header = bldr.request().make_header_full(credentials, &rs).unwrap();
+        self.header(http::header::AUTHORIZATION, format!("Hawk {}", req_header))
+    }
+}
+
+// TODO: ValidateHawkRequest?
+// TODO: SignRequestResponse?
+// TODO: ValidateHawkResponse for http::response::Response?

--- a/tests/bewit.rs
+++ b/tests/bewit.rs
@@ -1,0 +1,187 @@
+#![allow(unused_variables)]
+#![allow(unused_imports)]
+use failure::Fail;
+use futures::stream::Concat2;
+use futures::{future, Async, Future, Poll, Stream};
+use hawk::{Credentials, Key, PayloadHasher, RequestBuilder, SHA256};
+use hawk::{Header, RequestState, ResponseBuilder, SignRequest};
+use hyper;
+use hyper::header::{AUTHORIZATION, CONTENT_TYPE};
+use hyper::service::service_fn_ok;
+use hyper::{Body, Chunk, Client, HeaderMap, Request, Response, Server, StatusCode};
+use std::convert::TryInto;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use url::Url;
+
+#[derive(Fail, Debug)]
+pub enum TestError {
+    #[fail(display = "Test failure: {}", _0)]
+    Failure(String),
+
+    #[fail(display = "{}", _0)]
+    HawkError(hawk::Error),
+
+    #[fail(display = "{}", _0)]
+    Hyper(#[fail(cause)] hyper::Error),
+
+    #[fail(display = "{}", _0)]
+    Http(#[fail(cause)] http::Error),
+
+    #[fail(display = "{}", _0)]
+    HttpToStr(#[fail(cause)] http::header::ToStrError),
+}
+
+impl From<hawk::Error> for TestError {
+    fn from(e: hawk::Error) -> Self {
+        TestError::HawkError(e)
+    }
+}
+
+impl From<hyper::Error> for TestError {
+    fn from(e: hyper::Error) -> Self {
+        TestError::Hyper(e)
+    }
+}
+
+impl From<http::Error> for TestError {
+    fn from(e: http::Error) -> Self {
+        TestError::Http(e)
+    }
+}
+
+impl From<http::header::ToStrError> for TestError {
+    fn from(e: http::header::ToStrError) -> Self {
+        TestError::HttpToStr(e)
+    }
+}
+
+struct TestServer {
+    shutdown_tx: futures::sync::oneshot::Sender<()>,
+    local_address: std::net::SocketAddr,
+}
+
+impl TestServer {
+    fn new() -> Self {
+        let service_factory = move || {
+            service_fn_ok(move |req: Request<Body>| match TestServer::handle(req) {
+                Ok(res) => res,
+                Err(e) => Response::builder()
+                    .status(StatusCode::INTERNAL_SERVER_ERROR)
+                    .body(Body::from(format!("{}", e)))
+                    .unwrap(),
+            })
+        };
+
+        let addr = "127.0.0.1:0".parse().unwrap();
+        let server = Server::bind(&addr).serve(service_factory);
+        let local_address = server.local_addr();
+
+        // set up a channel to signal the server to stop
+        let (shutdown_tx, shutdown_rx) = futures::sync::oneshot::channel::<()>();
+        hyper::rt::spawn(server.with_graceful_shutdown(shutdown_rx).map_err(|e| {
+            // an error here is a failure to shut down, unlikely in a test context
+            eprintln!("server error: {}", e);
+        }));
+
+        Self {
+            shutdown_tx,
+            local_address,
+        }
+    }
+
+    fn handle(req: Request<Body>) -> Result<Response<Body>, TestError> {
+        let path_and_query = req.uri().path_and_query().unwrap().as_str();
+        let mut maybe_bewit = None;
+        let server_req = RequestBuilder::new("GET", "127.0.0.1", 80, path_and_query)
+            .extract_bewit(&mut maybe_bewit)?
+            .request();
+        let bewit = match maybe_bewit {
+            None => return Err(TestError::Failure(String::from("did not get bewit"))),
+            Some(bewit) => bewit,
+        };
+        if bewit.id() != "dh37fgj492je" {
+            return Err(TestError::Failure(String::from("invalid bewit id")));
+        }
+        let key = Key::new("werxhqb98rpaxn39848xrunpaw3489ruxnpa98w4rxn", SHA256).unwrap();
+        if !server_req.validate_bewit(&bewit, &key) {
+            return Err(TestError::Failure(String::from("bewit did not validate")));
+        }
+        let body = "Hello world";
+        Ok(Response::builder().body(Body::from(body))?)
+    }
+
+    fn stop(self) {
+        self.shutdown_tx.send(()).unwrap();
+    }
+}
+
+fn run_client(
+    credentials: &Credentials,
+    local_address: &std::net::SocketAddr,
+) -> impl Future<Item = (), Error = TestError> {
+    let mut url = Url::parse(&format!("http://{}/resource", local_address)).unwrap();
+
+    let hawk_req = RequestBuilder::new("GET", "127.0.0.1", 80, "/resource").request();
+    let bewit = hawk_req
+        .make_bewit_with_ttl(credentials, Duration::from_secs(30))
+        .unwrap();
+    url.set_query(Some(&format!("bewit={}", bewit.to_str())));
+
+    let req = Request::builder()
+        .method("GET")
+        .uri(url.as_str())
+        .body(Body::empty())
+        .unwrap();
+
+    let client = Client::new();
+    client
+        .request(req)
+        .map_err(|err| err.into())
+        .and_then(move |res| {
+            if res.status() != StatusCode::OK {
+                return Err(TestError::Failure(format!("Got status {}", res.status())).into());
+            }
+            Ok(())
+        })
+}
+
+fn run_client_server() {
+    let credentials = Credentials {
+        id: "dh37fgj492je".to_string(),
+        key: Key::new("werxhqb98rpaxn39848xrunpaw3489ruxnpa98w4rxn", SHA256).unwrap(),
+    };
+
+    // the async run doesn't allow returning anything, so we stuff the result of the
+    // client call here and check it on return.  There's probably an easier way!
+    let result: Arc<Mutex<Result<(), TestError>>> = Arc::new(Mutex::new(Err(TestError::Failure(
+        "client did not finish".to_string(),
+    ))));
+    let async_result = result.clone();
+
+    hyper::rt::run(hyper::rt::lazy(move || {
+        let test_server = TestServer::new();
+        hyper::rt::spawn(
+            run_client(&credentials, &test_server.local_address).then(move |r| {
+                test_server.stop();
+                *async_result.lock().unwrap() = r;
+                Ok(())
+            }),
+        );
+
+        futures::future::ok(())
+    }));
+
+    let r = result.lock().unwrap();
+    match *r {
+        Ok(_) => {}
+        Err(ref e) => {
+            panic!("{:?}", e);
+        }
+    }
+}
+
+#[test]
+fn bewit() {
+    run_client_server();
+}

--- a/tests/clientserver.rs
+++ b/tests/clientserver.rs
@@ -1,0 +1,376 @@
+#![allow(unused_variables)]
+#![allow(unused_imports)]
+use failure::Fail;
+use futures::stream::Concat2;
+use futures::{future, Async, Future, Poll, Stream};
+use hawk::{Credentials, Key, PayloadHasher, RequestBuilder, SHA256};
+use hawk::{Header, RequestState, ResponseBuilder, SignRequest};
+use hyper;
+use hyper::header::{AUTHORIZATION, CONTENT_TYPE};
+use hyper::service::service_fn;
+use hyper::{Body, Chunk, Client, HeaderMap, Request, Response, Server, StatusCode};
+use std::convert::TryInto;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use url::Url;
+
+#[derive(Clone)]
+struct TestParams {
+    client_send_hash: bool,
+    server_require_hash: bool,
+    server_send_hash: bool,
+    client_require_hash: bool,
+}
+
+#[derive(Fail, Debug)]
+pub enum TestError {
+    #[fail(display = "Test failure: {}", _0)]
+    Failure(String),
+
+    #[fail(display = "{}", _0)]
+    HawkError(hawk::Error),
+
+    #[fail(display = "{}", _0)]
+    Hyper(#[fail(cause)] hyper::Error),
+
+    #[fail(display = "{}", _0)]
+    Http(#[fail(cause)] http::Error),
+
+    #[fail(display = "{}", _0)]
+    HttpToStr(#[fail(cause)] http::header::ToStrError),
+}
+
+impl From<hawk::Error> for TestError {
+    fn from(e: hawk::Error) -> Self {
+        TestError::HawkError(e)
+    }
+}
+
+impl From<hyper::Error> for TestError {
+    fn from(e: hyper::Error) -> Self {
+        TestError::Hyper(e)
+    }
+}
+
+impl From<http::Error> for TestError {
+    fn from(e: http::Error) -> Self {
+        TestError::Http(e)
+    }
+}
+
+impl From<http::header::ToStrError> for TestError {
+    fn from(e: http::header::ToStrError) -> Self {
+        TestError::HttpToStr(e)
+    }
+}
+
+struct TestServer {
+    shutdown_tx: futures::sync::oneshot::Sender<()>,
+    local_address: std::net::SocketAddr,
+}
+
+type BoxFut = Box<dyn Future<Item = Response<Body>, Error = hyper::Error> + Send>;
+
+impl TestServer {
+    fn new(tp: &TestParams) -> Self {
+        let service_factory = match *tp {
+            TestParams {
+                client_send_hash,
+                server_require_hash,
+                server_send_hash,
+                client_require_hash,
+            } => {
+                move || {
+                    service_fn(move |req: Request<Body>| -> BoxFut {
+                        // Hyper doesn't allow you to look at a request and its body
+                        // at the same time without a clone.. so we clone..
+                        let headers = req.headers().clone();
+
+                        Box::new(req.into_body().concat2().and_then(move |chunk| {
+                            let res = match TestServer::handle(
+                                server_require_hash,
+                                server_send_hash,
+                                headers,
+                                &chunk,
+                            ) {
+                                Ok(res) => res,
+                                Err(e) => Response::builder()
+                                    .status(StatusCode::INTERNAL_SERVER_ERROR)
+                                    .body(Body::from(format!("{}", e)))
+                                    .unwrap(),
+                            };
+                            future::ok(res)
+                        }))
+                    })
+                }
+            }
+        };
+
+        let addr = "127.0.0.1:0".parse().unwrap();
+        let server = Server::bind(&addr).serve(service_factory);
+        let local_address = server.local_addr();
+
+        // set up a channel to signal the server to stop
+        let (shutdown_tx, shutdown_rx) = futures::sync::oneshot::channel::<()>();
+        hyper::rt::spawn(server.with_graceful_shutdown(shutdown_rx).map_err(|e| {
+            // an error here is a failure to shut down, unlikely in a test context
+            eprintln!("server error: {}", e);
+        }));
+
+        Self {
+            shutdown_tx,
+            local_address,
+        }
+    }
+
+    fn handle(
+        server_require_hash: bool,
+        server_send_hash: bool,
+        headers: HeaderMap,
+        body: &Chunk,
+    ) -> Result<Response<Body>, TestError> {
+        if !headers.contains_key(AUTHORIZATION) {
+            return Ok(Response::builder()
+                .status(StatusCode::UNAUTHORIZED)
+                .body(Body::from(""))?);
+        }
+
+        let header: Header = headers
+            .get(AUTHORIZATION)
+            .ok_or(TestError::Failure(String::from("No Authorization header")))?
+            .try_into()?;
+
+        // verify request
+        if header.id != Some(String::from("dh37fgj492je")) {
+            return Err(TestError::Failure(format!(
+                "id is {:?}, not dh37fgj492je",
+                header.id
+            )));
+        }
+
+        if !header.ext.is_none() {
+            return Err(TestError::Failure(String::from("ext is not None")));
+        }
+
+        let mut req_builder = RequestBuilder::new("POST", "127.0.0.1", 80, "/resource");
+
+        // if requested, calculate hash, add to builder
+        if server_require_hash {
+            let hash = PayloadHasher::hash(b"text/plain", SHA256, body)?;
+            req_builder = req_builder.hash(hash);
+        }
+
+        let request = req_builder.request();
+        let key = Key::new("werxhqb98rpaxn39848xrunpaw3489ruxnpa98w4rxn", SHA256).unwrap();
+        if !request.validate_header(&header, &key, Duration::from_secs(60)) {
+            return Err(TestError::Failure(String::from("header validation failed")));
+        }
+
+        let body = "Hello world";
+
+        let reqstate = RequestState {
+            nonce: header
+                .nonce
+                .ok_or_else(|| TestError::Failure(String::from("did not get nonce")))?,
+            ts: header
+                .ts
+                .ok_or_else(|| TestError::Failure(String::from("did not get ts")))?,
+        };
+        let mut res_builder = request.make_response_builder(&reqstate);
+
+        if server_send_hash {
+            let hash = PayloadHasher::hash(b"text/plain", SHA256, body)?;
+            res_builder = res_builder.hash(hash);
+        }
+
+        let res_header = res_builder.response().make_header(&key)?;
+
+        // sign response
+        let mut resp = Response::builder();
+        resp.header("Server-Authorization", res_header.header_value()?);
+        Ok(resp.body(Body::from(body))?)
+    }
+
+    fn stop(self) {
+        self.shutdown_tx.send(()).unwrap();
+    }
+}
+
+fn run_client(
+    tp: &TestParams,
+    credentials: Credentials,
+    local_address: &std::net::SocketAddr,
+) -> impl Future<Item = (), Error = TestError> {
+    let url = Url::parse(&format!("http://{}/resource", local_address)).unwrap();
+    let reqstate = RequestState::new().unwrap();
+
+    match *tp {
+        TestParams {
+            client_send_hash,
+            server_require_hash,
+            server_send_hash,
+            client_require_hash,
+        } => {
+            let body = "foo=bar";
+            let payload_hash = match client_send_hash {
+                true => Some(PayloadHasher::hash(b"text/plain", SHA256, body.as_bytes()).unwrap()),
+                false => None,
+            };
+
+            let req = Request::builder()
+                .method("POST")
+                .uri(url.as_str())
+                .sign_hawk(&credentials, &reqstate, |b| {
+                    b.hash(payload_hash)
+                        // we'll be using a dynamic port, but let's pretend it was 80 for
+                        // stability of the MAC
+                        .port(80)
+                })
+                .body(Body::from(body))
+                .unwrap();
+
+            let client = Client::new();
+            client
+                .request(req)
+                .map_err(|err| err.into())
+                .and_then(move |res| {
+                    if res.status() != StatusCode::OK {
+                        // returning an error from here is difficult, so just assert..
+                        assert!(false, "Got bad status");
+                    }
+
+                    let header: Header = res
+                        .headers()
+                        .get("Server-Authorization")
+                        .ok_or(TestError::Failure(String::from("No Authorization header")))
+                        .unwrap()
+                        .try_into()
+                        .unwrap();
+
+                    // get the body, tack on the header
+                    res.into_body().concat2().join(future::ok(header))
+                })
+                .map_err(|err| err.into())
+                .and_then(move |(body, header)| {
+                    let mut hawk_res_builder = ResponseBuilder::from_request_state(
+                        &reqstate,
+                        "POST",
+                        "127.0.0.1",
+                        80,
+                        "/resource",
+                    );
+
+                    if client_require_hash {
+                        let hash = PayloadHasher::hash(b"text/plain", SHA256, body)?;
+                        hawk_res_builder = hawk_res_builder.hash(hash);
+                    }
+
+                    let hawk_res = hawk_res_builder.response();
+
+                    if !hawk_res.validate_header(&header, &credentials.key) {
+                        return Err(TestError::Failure(format!(
+                            "Invalid server-authentication header {:?}",
+                            header
+                        )));
+                    }
+
+                    Ok(())
+                })
+        }
+    }
+}
+
+fn run_client_server(tp: &'static TestParams) {
+    // the async run doesn't allow returning anything, so we stuff the result of the
+    // client call here and check it on return.  There's probably an easier way!
+    let result: Arc<Mutex<Result<(), TestError>>> = Arc::new(Mutex::new(Err(TestError::Failure(
+        "client did not finish".to_string(),
+    ))));
+    let async_result = result.clone();
+
+    hyper::rt::run(hyper::rt::lazy(move || {
+        let test_server = TestServer::new(tp);
+        let credentials = Credentials {
+            id: "dh37fgj492je".to_string(),
+            key: Key::new("werxhqb98rpaxn39848xrunpaw3489ruxnpa98w4rxn", SHA256).unwrap(),
+        };
+
+        hyper::rt::spawn(
+            run_client(tp, credentials, &test_server.local_address).then(move |r| {
+                test_server.stop();
+                *async_result.lock().unwrap() = r;
+                Ok(())
+            }),
+        );
+
+        futures::future::ok(())
+    }));
+
+    let r = result.lock().unwrap();
+    match *r {
+        Ok(_) => {}
+        Err(ref e) => {
+            panic!("{:?}", e);
+        }
+    }
+}
+
+#[test]
+fn no_hashes() {
+    run_client_server(&TestParams {
+        client_send_hash: false,
+        server_require_hash: false,
+        server_send_hash: false,
+        client_require_hash: false,
+    });
+}
+
+#[test]
+fn client_send() {
+    run_client_server(&TestParams {
+        client_send_hash: true,
+        server_require_hash: false,
+        server_send_hash: false,
+        client_require_hash: false,
+    });
+}
+
+#[test]
+fn server_require() {
+    run_client_server(&TestParams {
+        client_send_hash: true,
+        server_require_hash: true,
+        server_send_hash: false,
+        client_require_hash: false,
+    });
+}
+
+#[test]
+fn server_send() {
+    run_client_server(&TestParams {
+        client_send_hash: true,
+        server_require_hash: true,
+        server_send_hash: true,
+        client_require_hash: false,
+    });
+}
+
+#[test]
+fn client_require() {
+    run_client_server(&TestParams {
+        client_send_hash: true,
+        server_require_hash: true,
+        server_send_hash: true,
+        client_require_hash: true,
+    });
+}
+
+#[test]
+fn response_hash_only() {
+    run_client_server(&TestParams {
+        client_send_hash: false,
+        server_require_hash: false,
+        server_send_hash: true,
+        client_require_hash: true,
+    });
+}

--- a/tests/interoperability.rs
+++ b/tests/interoperability.rs
@@ -1,0 +1,263 @@
+use hawk::{
+    Credentials, Header, Key, PayloadHasher, RequestBuilder, RequestState, ResponseBuilder,
+    SignRequest, SHA256,
+};
+use hyper;
+use hyper::rt::{self, Future, Stream};
+use hyper::{header, Body, Client, Request, StatusCode};
+use std::io::Read;
+use std::net::TcpListener;
+use std::path::Path;
+use std::process::{Child, Command};
+use std::str::FromStr;
+use std::time;
+use tokio::runtime::current_thread::Runtime;
+use url::Url;
+
+fn start_node_server() -> (Child, u16) {
+    let listener = TcpListener::bind(format!("127.0.0.1:{}", 0)).unwrap();
+    let callback_port = listener.local_addr().unwrap().port();
+
+    // check for `node_modules' first
+    let path = Path::new("tests/node/node_modules");
+    if !path.is_dir() {
+        panic!(
+            "Run `yarn` or `npm install` in tests/node, or test with --features \
+             no-interoperability"
+        );
+    }
+
+    let child = Command::new("node")
+        .arg("serve-one.js")
+        .arg(format!("{}", callback_port))
+        .current_dir("tests/node")
+        .spawn()
+        .expect("node command failed to start");
+
+    // wait until the process is ready, signalled by a connect to the callback port, and then
+    // return the port it provides. We know this will only get one connection, but iteration
+    // is easier anyway
+    #[cfg_attr(feature = "cargo-clippy", allow(never_loop))]
+    for stream in listener.incoming() {
+        let mut stream = stream.unwrap();
+
+        let mut data: Vec<u8> = vec![];
+        stream.read_to_end(&mut data).unwrap();
+        let port = u16::from_str(std::str::from_utf8(&data).unwrap()).unwrap();
+
+        drop(stream);
+        return (child, port);
+    }
+    unreachable!();
+}
+
+fn make_credentials() -> Credentials {
+    Credentials {
+        id: "dh37fgj492je".to_string(),
+        key: Key::new("werxhqb98rpaxn39848xrunpaw3489ruxnpa98w4rxn", SHA256).unwrap(),
+    }
+}
+
+/// Run the given function with a node child process, in a dedicated tokio current_thread runtime.
+/// The current_thread means that it's safe to use `assert!` in the function implementation.
+fn with_node_server<FN>(test_fn: FN)
+where
+    FN: FnOnce(u16) -> Box<dyn Future<Item = (), Error = ()>>,
+{
+    let (mut child, port) = start_node_server();
+
+    let mut runtime = Runtime::new().unwrap();
+    runtime
+        .block_on(rt::lazy(move || test_fn(port)))
+        .expect("error running test function");
+
+    // The Node server won't stop until we close the kept-alive HTTP connection, so this must be
+    // dropped before waiting for the child.
+    drop(runtime);
+
+    child.wait().expect("Failure waiting for child");
+}
+
+#[cfg_attr(feature = "no-interoperability", ignore)]
+#[test]
+fn client_with_header() {
+    with_node_server(|port| {
+        let credentials = make_credentials();
+        let url = Url::parse(&format!("http://localhost:{}/no-body", port)).unwrap();
+        let reqstate = RequestState::new().unwrap();
+
+        let req = Request::builder()
+            .method("GET")
+            .uri(url.as_str())
+            .sign_hawk(&credentials, &reqstate, |b| b)
+            .body(Body::empty())
+            .unwrap();
+
+        let client = Client::new();
+        Box::new(
+            client
+                .request(req)
+                .and_then(move |res| {
+                    // the `no-body` endpoint does not return server-authorization,
+                    // so there's nothing to verify here but the body content
+                    println!("Response: {}", res.status());
+                    println!("Headers: {:#?}", res.headers());
+                    assert_eq!(res.status(), StatusCode::OK);
+                    res.into_body().concat2().map(move |body| {
+                        assert_eq!(body.into_bytes(), "Hello Steve");
+                    })
+                })
+                .map_err(|err| {
+                    panic!("panic {}", err);
+                }),
+        )
+    });
+}
+
+#[cfg_attr(feature = "no-interoperability", ignore)]
+#[test]
+fn client_with_header_ext() {
+    with_node_server(|port| {
+        let credentials = make_credentials();
+        let url = Url::parse(&format!("http://localhost:{}/no-body", port)).unwrap();
+        let reqstate = RequestState::new().unwrap();
+
+        let req = Request::builder()
+            .method("GET")
+            .uri(url.as_str())
+            .sign_hawk(&credentials, &reqstate, |b| b.ext("extra!"))
+            .body(Body::empty())
+            .unwrap();
+
+        let client = Client::new();
+        Box::new(
+            client
+                .request(req)
+                .and_then(move |res| {
+                    // the `no-body` endpoint does not return server-authorization,
+                    // so there's nothing to verify here but the body content
+                    println!("Response: {}", res.status());
+                    println!("Headers: {:#?}", res.headers());
+                    assert_eq!(res.status(), StatusCode::OK);
+                    res.into_body().concat2().map(move |body| {
+                        assert_eq!(body.into_bytes(), "Hello Steve ext=extra!");
+                    })
+                })
+                .map_err(|err| {
+                    panic!("panic {}", err);
+                }),
+        )
+    });
+}
+
+#[cfg_attr(feature = "no-interoperability", ignore)]
+#[test]
+fn client_with_header_and_bodies() {
+    with_node_server(|port| {
+        let credentials = make_credentials();
+        let url = Url::parse(&format!("http://localhost:{}/resource", port)).unwrap();
+        let body = "foo=bar";
+        let hash = PayloadHasher::hash(b"text/plain", SHA256, body).unwrap();
+        let reqstate = RequestState::new().unwrap();
+
+        let req = Request::builder()
+            .method("POST")
+            .uri(url.as_str())
+            .header(header::CONTENT_TYPE, "text/plain")
+            .sign_hawk(&credentials, &reqstate, |b| b.hash(hash))
+            .body(Body::from(body))
+            .unwrap();
+        println!("Request: {:?}", req);
+
+        let client = Client::new();
+        Box::new(
+            client
+                .request(req)
+                .and_then(move |res| {
+                    println!("Response: {}", res.status());
+                    println!("Headers: {:#?}", res.headers());
+                    assert_eq!(res.status(), StatusCode::OK);
+                    let sa_header = res
+                        .headers()
+                        .get("server-authorization")
+                        .unwrap()
+                        .to_str()
+                        .unwrap()
+                        .to_string();
+                    let hasher = PayloadHasher::new(b"text/plain", SHA256).unwrap();
+                    res.into_body()
+                        .fold(
+                            hasher,
+                            |mut hasher, chunk| -> Result<PayloadHasher, hyper::Error> {
+                                hasher.update(&chunk).unwrap();
+                                Ok(hasher)
+                            },
+                        )
+                        .map(move |hasher| {
+                            let hash = hasher.finish().unwrap();
+                            println!("hash: {:?}", hash);
+                            println!("s-a header: {}", sa_header);
+                            let response = ResponseBuilder::from_request_state(
+                                &reqstate,
+                                "POST",
+                                "localhost",
+                                port,
+                                "/resource",
+                            )
+                            .hash(hash)
+                            .response();
+                            let server_header = Header::from_str(&sa_header[5..]).unwrap();
+                            assert!(response.validate_header(&server_header, &credentials.key));
+                        })
+                })
+                .map_err(|err| {
+                    panic!("Error {}", err);
+                }),
+        )
+    });
+}
+
+#[cfg_attr(feature = "no-interoperability", ignore)]
+#[test]
+fn client_with_bewit() {
+    with_node_server(|port| {
+        let credentials = make_credentials();
+        let url = Url::parse(&format!("http://localhost:{}/resource", port)).unwrap();
+        let hawk_req = RequestBuilder::from_url("GET", &url)
+            .unwrap()
+            .ext("ext-content")
+            .request();
+        let bewit = hawk_req
+            .make_bewit(
+                &credentials,
+                time::SystemTime::now() + time::Duration::from_secs(60),
+            )
+            .unwrap();
+        let mut url = url.clone();
+        url.set_query(Some(&format!("bewit={}", bewit.to_str())));
+
+        let req = Request::builder()
+            .method("GET")
+            .uri(url.as_str())
+            .body(Body::empty())
+            .unwrap();
+
+        let client = Client::new();
+        Box::new(
+            client
+                .request(req)
+                .and_then(move |res| {
+                    println!("Response: {}", res.status());
+                    println!("Headers: {:#?}", res.headers());
+                    assert_eq!(res.status(), StatusCode::OK);
+                    res.into_body().concat2().map(move |body| {
+                        println!("{:?}", body);
+                        assert_eq!(body.into_bytes(), "Hello Steve ext-content");
+                    })
+                })
+                .map_err(|err| {
+                    panic!("Error {}", err);
+                }),
+        )
+    })
+}

--- a/tests/node/.gitignore
+++ b/tests/node/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+yarn.lock

--- a/tests/node/package.json
+++ b/tests/node/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "hyper-hawk-tests",
+  "version": "1.0.0",
+  "description": "",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "MPL-2",
+  "dependencies": {
+    "body-parser": "^1.17.2",
+    "hawk": "^6.0.1",
+    "request": "^2.81.0"
+  }
+}

--- a/tests/node/serve-one.js
+++ b/tests/node/serve-one.js
@@ -1,0 +1,94 @@
+'use strict';
+/** Based on the JS Hawk exampel:
+ * https://github.com/hueniverse/hawk/blob/master/example/usage.js */
+
+var Http = require('http');
+var Request = require('request');
+var Hawk = require('hawk');
+var fs = require('fs');
+var net = require('net');
+var bodyParser = require('body-parser');
+
+var internals = {
+  credentials: {
+    dh37fgj492je: {
+      id: 'dh37fgj492je',                       // Required by Hawk.client.header
+      key: 'werxhqb98rpaxn39848xrunpaw3489ruxnpa98w4rxn',
+      algorithm: 'sha256',
+      user: 'Steve'
+    }
+  }
+};
+
+// Credentials lookup function
+
+var credentialsFunc = function (id, callback) {
+  return callback(null, internals.credentials[id]);
+};
+
+var server;
+
+// Create HTTP server
+
+var handler = function (req, res) {
+  if (req.method === 'POST') {
+    // for POST, parse the body and expect a header
+    var request_body = '';
+    req.on('data', function (data) {
+      request_body += data;
+    });
+    req.on('end', function () {
+      Hawk.server.authenticate(req,
+        credentialsFunc,
+        {payload: request_body},
+        function (err, credentials, artifacts) {
+          var payload = (!err ? 'Hello ' + credentials.user + ' ' + artifacts.ext : 'Shoosh!');
+          var headers = {
+            'Content-Type': 'text/plain',
+            'Server-Authorization': Hawk.server.header(credentials, artifacts, { payload, contentType: 'text/plain' })
+          };
+
+          res.writeHead(!err ? 200 : 401, headers);
+          res.end(payload);
+          server.close();
+        });
+    });
+  } else if (req.url === '/no-body') {
+    req.on('data', (data) => {});
+    req.on('end', function () {
+      Hawk.server.authenticate(req,
+        credentialsFunc,
+        {},
+        function (err, credentials, artifacts) {
+          var payload = (!err ? `Hello ${credentials.user}` + (artifacts.ext ? ` ext=${artifacts.ext}` : ''): 'Shoosh!');
+
+          res.writeHead(!err ? 200 : 401, {'Content-Type': 'text/plain'});
+          res.end(payload);
+          server.close();
+        });
+    });
+  } else {
+    // for GET, expect a bewit, and don't send a server-authorization response header
+    Hawk.uri.authenticate(req,
+      credentialsFunc,
+      {},
+      function (err, credentials, artifacts) {
+        var payload = (!err ? 'Hello ' + credentials.user + ' ' + artifacts.ext : 'Shoosh!');
+        var headers = {'Content-Type': 'text/plain'};
+        res.writeHead(!err ? 200 : 401, headers);
+        res.end(payload);
+        server.close();
+      });
+  }
+};
+
+var CALLBACK_PORT = parseInt(process.argv[2]);
+
+server = Http.createServer(handler).listen(0, '127.0.0.1', function() {
+  // parent process waits for listening to complete by waiting for a tcp
+  // connection on this port, containing the listening TCP port.
+  net.createConnection({port: CALLBACK_PORT, host: "127.0.0.1"}, function() {
+    this.write(server.address().port.toString());
+    this.end();;
+  });
+});


### PR DESCRIPTION
This change incorporates functionality for use of this crate with the `http`
crate.  Most importantly, it adds support for signing request builders:

```rust
    let req = Request::builder()
	.method(method)
	.uri(uri)
	.sign_hawk(&credentials, &reqstate, |b| {
	    b.hash(payload_hash)
	})
	.body(Body::from(body))
	.unwrap();
```

The change incorporates a few other changes to make this crate easier to use in
an asynchronous context, where liberal borrowing of values ties the borrow
checker in knots.

In detail:

Breaking changes to API:
* `Request` and `Response` now take `hash` by value
* `Request.make_header_full` takes a new `RequestState` instead of nonce and timestamp
* `Request.make_response_builder` and `Response::from_request_state` now take a `RequestState` instead of a `Header`
* `Response::from_request_header` is now `from_request_state` and takes a `RequestState`.

Non-breaking changes:
* Adds a new SignRequest trait
* Adds interoperability and client/server tests previously in the hyper-hawk crate
  (but note that this crate does not require hyper and should work with any other web
  crate that uses the `http` crate)
* Uses a RequestState object to hold state sent in Request and verified in Response
* A Hawk header can be converted from an http::HeaderValue with `h.try_into()`
* A Hawk header can be converted into an http::HeaderValue with `h.header_value()`.

Fixes #32.