### PR TITLE
feat: add `dbg!()` error reports when processing validation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,4 @@ url = "2.0.0"
 rand = "0.7.0"
 failure = { version = "0.1.5", features = ["derive"] }
 once_cell = "1.0.1"
+log = "0.4.8"

--- a/src/request.rs
+++ b/src/request.rs
@@ -4,12 +4,12 @@ use crate::error::*;
 use crate::header::Header;
 use crate::mac::{Mac, MacType};
 use crate::response::ResponseBuilder;
+use log::debug;
 use std::borrow::Cow;
 use std::str;
 use std::str::FromStr;
 use std::time::{Duration, SystemTime};
 use url::{Position, Url};
-use log::debug;
 
 /// Request represents a single HTTP request.
 ///
@@ -223,7 +223,10 @@ impl<'a> Request<'a> {
             ts.duration_since(now).unwrap()
         };
         if skew > ts_skew {
-            debug!("bad timestamp skew, timestamp too old? detected skew: {:?}, ts_skew: {:?}", &skew, &ts_skew);
+            debug!(
+                "bad timestamp skew, timestamp too old? detected skew: {:?}, ts_skew: {:?}",
+                &skew, &ts_skew
+            );
             return false;
         }
 
@@ -607,7 +610,6 @@ mod test {
 
     #[test]
     fn test_url_builder_with_bewit_invalid() {
-
         let url = Url::parse("https://example.com/foo?bewit=1234").unwrap();
         let bldr = RequestBuilder::from_url("GET", &url).unwrap();
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -149,18 +149,21 @@ impl<'a> Request<'a> {
         let ts = match header.ts {
             Some(ts) => ts,
             None => {
+                dbg!("missing timestamp from header");
                 return false;
             }
         };
         let nonce = match header.nonce {
             Some(ref nonce) => nonce,
             None => {
+                dbg!("missing nonce from header");
                 return false;
             }
         };
         let header_mac = match header.mac {
             Some(ref mac) => mac,
             None => {
+                dbg!("missing mac from header");
                 return false;
             }
         };
@@ -188,10 +191,12 @@ impl<'a> Request<'a> {
         ) {
             Ok(calculated_mac) => {
                 if &calculated_mac != header_mac {
+                    dbg!("calculated mac doesn't match header");
                     return false;
                 }
             }
-            Err(_) => {
+            Err(e) => {
+                dbg!("mac error: ", e);
                 return false;
             }
         };
@@ -200,9 +205,11 @@ impl<'a> Request<'a> {
         if let Some(local_hash) = self.hash {
             if let Some(server_hash) = header_hash {
                 if local_hash != server_hash {
+                    dbg!("server hash doesn't match header");
                     return false;
                 }
             } else {
+                dbg!("missing hash from header");
                 return false;
             }
         }
@@ -215,6 +222,7 @@ impl<'a> Request<'a> {
             ts.duration_since(now).unwrap()
         };
         if skew > ts_skew {
+            dbg!("bad timestamp skew, timestamp too old?", &skew, &ts_skew);
             return false;
         }
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -9,6 +9,7 @@ use std::str;
 use std::str::FromStr;
 use std::time::{Duration, SystemTime};
 use url::{Position, Url};
+use log::debug;
 
 /// Request represents a single HTTP request.
 ///
@@ -149,21 +150,21 @@ impl<'a> Request<'a> {
         let ts = match header.ts {
             Some(ts) => ts,
             None => {
-                dbg!("missing timestamp from header");
+                debug!("missing timestamp from header");
                 return false;
             }
         };
         let nonce = match header.nonce {
             Some(ref nonce) => nonce,
             None => {
-                dbg!("missing nonce from header");
+                debug!("missing nonce from header");
                 return false;
             }
         };
         let header_mac = match header.mac {
             Some(ref mac) => mac,
             None => {
-                dbg!("missing mac from header");
+                debug!("missing mac from header");
                 return false;
             }
         };
@@ -191,12 +192,12 @@ impl<'a> Request<'a> {
         ) {
             Ok(calculated_mac) => {
                 if &calculated_mac != header_mac {
-                    dbg!("calculated mac doesn't match header");
+                    debug!("calculated mac doesn't match header");
                     return false;
                 }
             }
             Err(e) => {
-                dbg!("mac error: ", e);
+                debug!("unexpected mac error: {:?}", e);
                 return false;
             }
         };
@@ -205,11 +206,11 @@ impl<'a> Request<'a> {
         if let Some(local_hash) = self.hash {
             if let Some(server_hash) = header_hash {
                 if local_hash != server_hash {
-                    dbg!("server hash doesn't match header");
+                    debug!("server hash doesn't match header");
                     return false;
                 }
             } else {
-                dbg!("missing hash from header");
+                debug!("missing hash from header");
                 return false;
             }
         }
@@ -222,7 +223,7 @@ impl<'a> Request<'a> {
             ts.duration_since(now).unwrap()
         };
         if skew > ts_skew {
-            dbg!("bad timestamp skew, timestamp too old?", &skew, &ts_skew);
+            debug!("bad timestamp skew, timestamp too old? detected skew: {:?}, ts_skew: {:?}", &skew, &ts_skew);
             return false;
         }
 
@@ -606,6 +607,7 @@ mod test {
 
     #[test]
     fn test_url_builder_with_bewit_invalid() {
+
         let url = Url::parse("https://example.com/foo?bewit=1234").unwrap();
         let bldr = RequestBuilder::from_url("GET", &url).unwrap();
 


### PR DESCRIPTION
Hawk currently just bails on error meaning that determining what went
wrong can be difficult. I've found adding a few `dbg!()` statements can
help quickly isolate problems in test cases, setup, initial connection
tests, etc.