### PR TITLE
Replace failure with thiserror and anyhow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ ring = { version = "0.16.0", optional = true }
 openssl = { version = "0.10.20", optional = true }
 url = "2.0.0"
 rand = "0.7.0"
-failure = { version = "0.1.5", features = ["derive"] }
+thiserror = "1.0"
+anyhow = "1.0"
 once_cell = "1.0.1"
 log = "0.4.8"

--- a/src/crypto/holder.rs
+++ b/src/crypto/holder.rs
@@ -1,11 +1,10 @@
 use super::Cryptographer;
-use failure::Fail;
 use once_cell::sync::OnceCell;
 
 static CRYPTOGRAPHER: OnceCell<&'static dyn Cryptographer> = OnceCell::new();
 
-#[derive(Debug, Fail)]
-#[fail(display = "Cryptographer already initialized")]
+#[derive(Debug, thiserror::Error)]
+#[error("Cryptographer already initialized")]
 pub struct SetCryptographerError(());
 
 /// Sets the global object that will be used for cryptographic operations.

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -9,7 +9,6 @@
 //! [`Cryptographer`] and using the [`set_cryptographer`] or
 //! [`set_boxed_cryptographer`] functions.
 use crate::DigestAlgorithm;
-use failure::Fail;
 
 pub(crate) mod holder;
 pub(crate) use holder::get_crypographer;
@@ -22,20 +21,17 @@ mod ring;
 #[cfg(not(any(feature = "use_ring", feature = "use_openssl")))]
 pub use self::holder::{set_boxed_cryptographer, set_cryptographer};
 
-#[derive(Debug, Fail)]
+#[derive(Debug, thiserror::Error)]
 pub enum CryptoError {
     /// The configured cryptographer does not support the digest algorithm
     /// specified. This should only happen for custom `Cryptographer` implementations
-    #[fail(
-        display = "Digest algorithm {:?} is unsupported by this Cryptographer",
-        _0
-    )]
+    #[error("Digest algorithm {0:?} is unsupported by this Cryptographer")]
     UnsupportedDigest(DigestAlgorithm),
 
     /// The configured cryptographer implementation failed to perform an
     /// operation in some way.
-    #[fail(display = "{}", _0)]
-    Other(#[fail(cause)] failure::Error),
+    #[error("{0}")]
+    Other(#[source] anyhow::Error),
 }
 
 /// A trait encapsulating the cryptographic operations required by this library.

--- a/src/crypto/ring.rs
+++ b/src/crypto/ring.rs
@@ -1,13 +1,12 @@
 use super::{CryptoError, Cryptographer, Hasher, HmacKey};
 use crate::DigestAlgorithm;
-use failure::err_msg;
 use ring::{digest, hmac};
 use std::convert::{TryFrom, TryInto};
 
 impl From<ring::error::Unspecified> for CryptoError {
     // Ring's errors are entirely opaque
     fn from(_: ring::error::Unspecified) -> Self {
-        CryptoError::Other(err_msg("Unspecified ring error"))
+        CryptoError::Other(anyhow::Error::msg("Unspecified ring error"))
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,48 +1,47 @@
 use crate::crypto::CryptoError;
-use failure::Fail;
 
 pub type Result<T> = std::result::Result<T, Error>;
 
-#[derive(Fail, Debug)]
+#[derive(thiserror::Error, Debug)]
 pub enum Error {
-    #[fail(display = "Unparseable Hawk header: {}", _0)]
+    #[error("Unparseable Hawk header: {0}")]
     HeaderParseError(String),
 
-    #[fail(display = "Invalid url: {}", _0)]
+    #[error("Invalid url: {0}")]
     InvalidUrl(String),
 
-    #[fail(display = "Missing `ts` attribute in Hawk header")]
+    #[error("Missing `ts` attribute in Hawk header")]
     MissingTs,
 
-    #[fail(display = "Missing `nonce` attribute in Hawk header")]
+    #[error("Missing `nonce` attribute in Hawk header")]
     MissingNonce,
 
-    #[fail(display = "{}", _0)]
-    InvalidBewit(#[fail(cause)] InvalidBewit),
+    #[error("{0}")]
+    InvalidBewit(#[source] InvalidBewit),
 
-    #[fail(display = "{}", _0)]
-    Io(#[fail(cause)] std::io::Error),
+    #[error("{0}")]
+    Io(#[source] std::io::Error),
 
-    #[fail(display = "Base64 Decode error: {}", _0)]
-    Decode(#[fail(cause)] base64::DecodeError),
+    #[error("Base64 Decode error: {0}")]
+    Decode(#[source] base64::DecodeError),
 
-    #[fail(display = "Crypto error: {}", _0)]
-    Crypto(#[fail(cause)] CryptoError),
+    #[error("Crypto error: {0}")]
+    Crypto(#[source] CryptoError),
 }
 
-#[derive(Fail, Debug, PartialEq)]
+#[derive(thiserror::Error, Debug, PartialEq)]
 pub enum InvalidBewit {
-    #[fail(display = "Multiple bewits in URL")]
+    #[error("Multiple bewits in URL")]
     Multiple,
-    #[fail(display = "Invalid bewit format")]
+    #[error("Invalid bewit format")]
     Format,
-    #[fail(display = "Invalid bewit id")]
+    #[error("Invalid bewit id")]
     Id,
-    #[fail(display = "Invalid bewit exp")]
+    #[error("Invalid bewit exp")]
     Exp,
-    #[fail(display = "Invalid bewit mac")]
+    #[error("Invalid bewit mac")]
     Mac,
-    #[fail(display = "Invalid bewit ext")]
+    #[error("Invalid bewit ext")]
     Ext,
 }
 


### PR DESCRIPTION
Hello team!
We are in the process of replacing the failure crate in firefox [application-services](https://github.com/mozilla/application-services/pull/3132) since failure is deprecated. thiserror and anyhow are the recommended replacements (since they create errors that impl std::error::Error)

Since some components consume hawk I thought I should create a pull-request here too, it's a mostly intuitive change. Ran `cargo test` and `cargo fmt` before openning this.

Let me know what you think!

fixes #55 