### PR TITLE
Hide base64::DecodeError

### DIFF
--- a/src/bewit.rs
+++ b/src/bewit.rs
@@ -81,7 +81,7 @@ const BACKSLASH: u8 = b'\\';
 impl<'a> FromStr for Bewit<'a> {
     type Err = Error;
     fn from_str(bewit: &str) -> Result<Bewit<'a>> {
-        let bewit = base64::decode(bewit).map_err(|e| Error::from_base64_error(e))?;
+        let bewit = base64::decode(bewit).map_err(Error::from_base64_error)?;
 
         let parts: Vec<&[u8]> = bewit.split(|c| *c == BACKSLASH).collect();
         if parts.len() != 4 {

--- a/src/bewit.rs
+++ b/src/bewit.rs
@@ -81,7 +81,7 @@ const BACKSLASH: u8 = b'\\';
 impl<'a> FromStr for Bewit<'a> {
     type Err = Error;
     fn from_str(bewit: &str) -> Result<Bewit<'a>> {
-        let bewit = base64::decode(bewit)?;
+        let bewit = base64::decode(bewit).map_err(|e| Error::from_base64_error(e))?;
 
         let parts: Vec<&[u8]> = bewit.split(|c| *c == BACKSLASH).collect();
         if parts.len() != 4 {

--- a/src/error.rs
+++ b/src/error.rs
@@ -23,7 +23,7 @@ pub enum Error {
     Io(#[source] std::io::Error),
 
     #[error("Base64 Decode error: {0}")]
-    Decode(#[source] base64::DecodeError),
+    Decode(String),
 
     #[error("Crypto error: {0}")]
     Crypto(#[source] CryptoError),
@@ -47,7 +47,7 @@ pub enum InvalidBewit {
 
 impl From<base64::DecodeError> for Error {
     fn from(e: base64::DecodeError) -> Self {
-        Error::Decode(e)
+        Error::Decode(e.to_string())
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -45,8 +45,10 @@ pub enum InvalidBewit {
     Ext,
 }
 
-impl From<base64::DecodeError> for Error {
-    fn from(e: base64::DecodeError) -> Self {
+impl Error {
+    // this cannot be a `From<..>` implementation as that publicly exposes the version of base64
+    // used in this crate.
+    pub(crate) fn from_base64_error(e: base64::DecodeError) -> Self {
         Error::Decode(e.to_string())
     }
 }


### PR DESCRIPTION
This allows unlinking rust-hawk and base64 major revisions.

See #65.