### PR TITLE
Fix URL-safe base64 encoding to be as it has been 

### DIFF
--- a/src/b64.rs
+++ b/src/b64.rs
@@ -5,12 +5,12 @@ use base64::engine::{
     DecodePaddingMode,
 };
 
-/// BEWIT_ENGINE encodes to a url-safe value with no padding.
+/// BEWIT_ENGINE encodes to a url-safe value with no padding, but indifferent to padding on decode.
 pub(crate) const BEWIT_ENGINE: FastPortable = FastPortable::from(
     &base64::alphabet::URL_SAFE,
     FastPortableConfig::new()
         .with_encode_padding(false)
-        .with_decode_padding_mode(DecodePaddingMode::RequireNone),
+        .with_decode_padding_mode(DecodePaddingMode::Indifferent),
 );
 
 /// STANDARD_ENGINE encodes with the standard alphabet and includes padding.


### PR DESCRIPTION
On further analysis, it turns out URL_SAFE_NO_PAD was indifferent to padding, so be the same here.