### PR TITLE
Fix clippy lints

### DIFF
--- a/src/bewit.rs
+++ b/src/bewit.rs
@@ -1,7 +1,6 @@
 use crate::b64;
 use crate::error::*;
 use crate::mac::Mac;
-use base64;
 use base64::Engine;
 use std::borrow::Cow;
 use std::str;
@@ -28,10 +27,7 @@ impl<'a> Bewit<'a> {
             id: Cow::Borrowed(id),
             exp,
             mac: Cow::Owned(mac),
-            ext: match ext {
-                Some(s) => Some(Cow::Borrowed(s)),
-                None => None,
-            },
+            ext: ext.map(Cow::Borrowed),
         }
     }
 
@@ -51,7 +47,7 @@ impl<'a> Bewit<'a> {
             }
         );
 
-        b64::BEWIT_ENGINE.encode(&raw)
+        b64::BEWIT_ENGINE.encode(raw)
     }
 
     /// Get the Bewit's client identifier
@@ -191,30 +187,30 @@ mod test {
 
     #[test]
     fn test_from_str_invalid_too_many_parts() {
-        let bewit = b64::BEWIT_ENGINE.encode(&"a\\123\\abc\\ext\\WHUT?".as_bytes());
+        let bewit = b64::BEWIT_ENGINE.encode("a\\123\\abc\\ext\\WHUT?".as_bytes());
         assert!(Bewit::from_str(&bewit).is_err());
     }
 
     #[test]
     fn test_from_str_invalid_too_few_parts() {
-        let bewit = b64::BEWIT_ENGINE.encode(&"a\\123\\abc".as_bytes());
+        let bewit = b64::BEWIT_ENGINE.encode("a\\123\\abc".as_bytes());
         assert!(Bewit::from_str(&bewit).is_err());
     }
 
     #[test]
     fn test_from_str_invalid_not_utf8() {
-        let a = 'a' as u8;
-        let one = '1' as u8;
-        let slash = '\\' as u8;
+        let a = b'a';
+        let one = b'1';
+        let slash = b'\\';
         let invalid1 = 0u8;
         let invalid2 = 159u8;
-        let bewit = b64::BEWIT_ENGINE.encode(&[invalid1, invalid2, slash, one, slash, a, slash, a]);
+        let bewit = b64::BEWIT_ENGINE.encode([invalid1, invalid2, slash, one, slash, a, slash, a]);
         assert!(Bewit::from_str(&bewit).is_err());
-        let bewit = b64::BEWIT_ENGINE.encode(&[a, slash, invalid1, invalid2, slash, a, slash, a]);
+        let bewit = b64::BEWIT_ENGINE.encode([a, slash, invalid1, invalid2, slash, a, slash, a]);
         assert!(Bewit::from_str(&bewit).is_err());
-        let bewit = b64::BEWIT_ENGINE.encode(&[a, slash, one, slash, invalid1, invalid2, slash, a]);
+        let bewit = b64::BEWIT_ENGINE.encode([a, slash, one, slash, invalid1, invalid2, slash, a]);
         assert!(Bewit::from_str(&bewit).is_err());
-        let bewit = b64::BEWIT_ENGINE.encode(&[a, slash, one, slash, a, slash, invalid1, invalid2]);
+        let bewit = b64::BEWIT_ENGINE.encode([a, slash, one, slash, a, slash, invalid1, invalid2]);
         assert!(Bewit::from_str(&bewit).is_err());
     }
 }

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -1,16 +1,11 @@
 use crate::crypto::{self, HmacKey};
 
 #[derive(Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Hash, Debug)]
+#[non_exhaustive]
 pub enum DigestAlgorithm {
     Sha256,
     Sha384,
     Sha512,
-    // Indicate that this isn't an enum that anyone should match on, and that we
-    // reserve the right to add to this enumeration without making a major
-    // version bump. Once https://github.com/rust-lang/rfcs/blob/master/text/2008-non-exhaustive.md
-    // is stabilized, that should be used instead.
-    #[doc(hidden)]
-    _Nonexhaustive,
 }
 
 /// Hawk key.

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -79,5 +79,5 @@ pub(crate) fn constant_time_compare(a: &[u8], b: &[u8]) -> bool {
 }
 
 pub(crate) fn new_hasher(algorithm: DigestAlgorithm) -> Result<Box<dyn Hasher>, CryptoError> {
-    Ok(get_crypographer().new_hasher(algorithm)?)
+    get_crypographer().new_hasher(algorithm)
 }

--- a/src/crypto/ring.rs
+++ b/src/crypto/ring.rs
@@ -81,7 +81,6 @@ impl TryFrom<DigestAlgorithm> for &'static digest::Algorithm {
             DigestAlgorithm::Sha256 => Ok(&digest::SHA256),
             DigestAlgorithm::Sha384 => Ok(&digest::SHA384),
             DigestAlgorithm::Sha512 => Ok(&digest::SHA512),
-            algo => Err(CryptoError::UnsupportedDigest(algo)),
         }
     }
 }
@@ -93,7 +92,6 @@ impl TryFrom<DigestAlgorithm> for hmac::Algorithm {
             DigestAlgorithm::Sha256 => Ok(hmac::HMAC_SHA256),
             DigestAlgorithm::Sha384 => Ok(hmac::HMAC_SHA384),
             DigestAlgorithm::Sha512 => Ok(hmac::HMAC_SHA512),
-            algo => Err(CryptoError::UnsupportedDigest(algo)),
         }
     }
 }

--- a/src/header.rs
+++ b/src/header.rs
@@ -78,7 +78,7 @@ impl Header {
     pub fn fmt_header(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut sep = "";
         if let Some(ref id) = self.id {
-            write!(f, "{}id=\"{}\"", sep, id)?;
+            write!(f, "{sep}id=\"{id}\"")?;
             sep = ", ";
         }
         if let Some(ref ts) = self.ts {
@@ -91,7 +91,7 @@ impl Header {
             sep = ", ";
         }
         if let Some(ref nonce) = self.nonce {
-            write!(f, "{}nonce=\"{}\"", sep, nonce)?;
+            write!(f, "{sep}nonce=\"{nonce}\"")?;
             sep = ", ";
         }
         if let Some(ref mac) = self.mac {
@@ -99,7 +99,7 @@ impl Header {
             sep = ", ";
         }
         if let Some(ref ext) = self.ext {
-            write!(f, "{}ext=\"{}\"", sep, ext)?;
+            write!(f, "{sep}ext=\"{ext}\"")?;
             sep = ", ";
         }
         if let Some(ref hash) = self.hash {
@@ -107,11 +107,11 @@ impl Header {
             sep = ", ";
         }
         if let Some(ref app) = self.app {
-            write!(f, "{}app=\"{}\"", sep, app)?;
+            write!(f, "{sep}app=\"{app}\"")?;
             sep = ", ";
         }
         if let Some(ref dlg) = self.dlg {
-            write!(f, "{}dlg=\"{}\"", sep, dlg)?;
+            write!(f, "{sep}dlg=\"{dlg}\"")?;
         }
         Ok(())
     }
@@ -126,7 +126,7 @@ impl fmt::Display for Header {
 impl FromStr for Header {
     type Err = Error;
     fn from_str(s: &str) -> Result<Header> {
-        let mut p = &s[..];
+        let mut p = s;
 
         // Required attributes
         let mut id: Option<&str> = None;
@@ -152,7 +152,7 @@ impl FromStr for Header {
                     "Missing right hand side of =".into(),
                 ));
             }
-            p = (&p[assign_end + 1..]).trim_start();
+            p = p[assign_end + 1..].trim_start();
             if !p.starts_with('\"') {
                 return Err(Error::HeaderParseError("Expected opening quote".into()));
             }
@@ -200,32 +200,14 @@ impl FromStr for Header {
         }
 
         Ok(Header {
-            id: match id {
-                Some(id) => Some(id.to_string()),
-                None => None,
-            },
+            id: id.map(|id| id.to_string()),
             ts,
-            nonce: match nonce {
-                Some(nonce) => Some(nonce.to_string()),
-                None => None,
-            },
-            mac: match mac {
-                Some(mac) => Some(Mac::from(mac)),
-                None => None,
-            },
-            ext: match ext {
-                Some(ext) => Some(ext.to_string()),
-                None => None,
-            },
+            nonce: nonce.map(|nonce| nonce.to_string()),
+            mac: mac.map(Mac::from),
+            ext: ext.map(|ext| ext.to_string()),
             hash,
-            app: match app {
-                Some(app) => Some(app.to_string()),
-                None => None,
-            },
-            dlg: match dlg {
-                Some(dlg) => Some(dlg.to_string()),
-                None => None,
-            },
+            app: app.map(|app| app.to_string()),
+            dlg: dlg.map(|dlg| dlg.to_string()),
         })
     }
 }
@@ -351,13 +333,13 @@ mod test {
     #[test]
     fn from_str_no_field() {
         let s = Header::from_str("").unwrap();
-        assert!(s.id == None);
-        assert!(s.ts == None);
-        assert!(s.nonce == None);
-        assert!(s.mac == None);
-        assert!(s.ext == None);
-        assert!(s.app == None);
-        assert!(s.dlg == None);
+        assert!(s.id.is_none());
+        assert!(s.ts.is_none());
+        assert!(s.nonce.is_none());
+        assert!(s.mac.is_none());
+        assert!(s.ext.is_none());
+        assert!(s.app.is_none());
+        assert!(s.dlg.is_none());
     }
 
     #[test]
@@ -378,9 +360,9 @@ mod test {
                     6, 93, 75, 75, 52, 140, 102, 163, 91, 233, 50, 135, 233, 44, 1
                 ]))
         );
-        assert!(s.ext == None);
-        assert!(s.app == None);
-        assert!(s.dlg == None);
+        assert!(s.ext.is_none());
+        assert!(s.app.is_none());
+        assert!(s.dlg.is_none());
     }
 
     #[test]
@@ -402,17 +384,17 @@ mod test {
                 ]))
         );
         assert!(s.ext == Some("some-app-ext-data".to_string()));
-        assert!(s.app == None);
-        assert!(s.dlg == None);
+        assert!(s.app.is_none());
+        assert!(s.dlg.is_none());
     }
 
     #[test]
     fn to_str_no_fields() {
         // must supply a type for S, since it is otherwise unused
         let s = Header::new::<String>(None, None, None, None, None, None, None, None).unwrap();
-        let formatted = format!("{}", s);
-        println!("got: {}", formatted);
-        assert!(formatted == "")
+        let formatted = format!("{s}");
+        println!("got: {formatted}");
+        assert!(formatted.is_empty())
     }
 
     #[test]
@@ -431,8 +413,8 @@ mod test {
             None,
         )
         .unwrap();
-        let formatted = format!("{}", s);
-        println!("got: {}", formatted);
+        let formatted = format!("{s}");
+        println!("got: {formatted}");
         assert!(
             formatted
                 == "id=\"dh37fgj492je\", ts=\"1353832234\", nonce=\"j4h3g2\", \
@@ -456,8 +438,8 @@ mod test {
             Some("my-dlg"),
         )
         .unwrap();
-        let formatted = format!("{}", s);
-        println!("got: {}", formatted);
+        let formatted = format!("{s}");
+        println!("got: {formatted}");
         assert!(
             formatted
                 == "id=\"dh37fgj492je\", ts=\"1353832234\", nonce=\"j4h3g2\", \
@@ -482,8 +464,8 @@ mod test {
             Some("my-dlg"),
         )
         .unwrap();
-        let formatted = format!("{}", s);
-        println!("got: {}", s);
+        let formatted = format!("{s}");
+        println!("got: {s}");
         let s2 = Header::from_str(&formatted).unwrap();
         assert!(s2 == s);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,29 +13,27 @@
 //! use hawk::{RequestBuilder, Credentials, Key, SHA256, PayloadHasher};
 //! use std::time::{Duration, UNIX_EPOCH};
 //!
-//! fn main() {
-//!     // provide the Hawk id and key
-//!     let credentials = Credentials {
-//!         id: "test-client".to_string(),
-//!         key: Key::new(vec![99u8; 32], SHA256).unwrap(),
-//!     };
+//! // provide the Hawk id and key
+//! let credentials = Credentials {
+//!     id: "test-client".to_string(),
+//!     key: Key::new(vec![99u8; 32], SHA256).unwrap(),
+//! };
 //!
-//!     let payload_hash = PayloadHasher::hash("text/plain", SHA256, "request-body").unwrap();
+//! let payload_hash = PayloadHasher::hash("text/plain", SHA256, "request-body").unwrap();
 //!
-//!     // provide the details of the request to be authorized
-//!      let request = RequestBuilder::new("POST", "example.com", 80, "/v1/users")
-//!         .hash(&payload_hash[..])
-//!         .request();
+//! // provide the details of the request to be authorized
+//!  let request = RequestBuilder::new("POST", "example.com", 80, "/v1/users")
+//!     .hash(&payload_hash[..])
+//!     .request();
 //!
-//!     // Get the resulting header, including the calculated MAC; this involves a random
-//!     // nonce, so the MAC will be different on every request.
-//!     let header = request.make_header(&credentials).unwrap();
+//! // Get the resulting header, including the calculated MAC; this involves a random
+//! // nonce, so the MAC will be different on every request.
+//! let header = request.make_header(&credentials).unwrap();
 //!
-//!     // the header would the be attached to the request
-//!     assert_eq!(header.id.unwrap(), "test-client");
-//!     assert_eq!(header.mac.unwrap().len(), 32);
-//!     assert_eq!(header.hash.unwrap().len(), 32);
-//! }
+//! // the header would the be attached to the request
+//! assert_eq!(header.id.unwrap(), "test-client");
+//! assert_eq!(header.mac.unwrap().len(), 32);
+//! assert_eq!(header.hash.unwrap().len(), 32);
 //! ```
 //!
 //! A client that wishes to use a bewit (URL parameter) can do so as follows:
@@ -68,31 +66,29 @@
 //! use hawk::mac::Mac;
 //! use std::time::{Duration, UNIX_EPOCH};
 //!
-//! fn main() {
-//!    let mac = Mac::from(vec![7, 22, 226, 240, 84, 78, 49, 75, 115, 144, 70,
-//!                             106, 102, 134, 144, 128, 225, 239, 95, 132, 202,
-//!                             154, 213, 118, 19, 63, 183, 108, 215, 134, 118, 115]);
-//!    // get the header (usually from the received request; constructed directly here)
-//!    let hdr = Header::new(Some("dh37fgj492je"),
-//!                          Some(UNIX_EPOCH + Duration::new(1353832234, 0)),
-//!                          Some("j4h3g2"),
-//!                          Some(mac),
-//!                          Some("my-ext-value"),
-//!                          Some(vec![1, 2, 3, 4]),
-//!                          Some("my-app"),
-//!                          Some("my-dlg")).unwrap();
+//! let mac = Mac::from(vec![7, 22, 226, 240, 84, 78, 49, 75, 115, 144, 70,
+//!                          106, 102, 134, 144, 128, 225, 239, 95, 132, 202,
+//!                          154, 213, 118, 19, 63, 183, 108, 215, 134, 118, 115]);
+//! // get the header (usually from the received request; constructed directly here)
+//! let hdr = Header::new(Some("dh37fgj492je"),
+//!                       Some(UNIX_EPOCH + Duration::new(1353832234, 0)),
+//!                       Some("j4h3g2"),
+//!                       Some(mac),
+//!                       Some("my-ext-value"),
+//!                       Some(vec![1, 2, 3, 4]),
+//!                       Some("my-app"),
+//!                       Some("my-dlg")).unwrap();
 //!
-//!    // build a request object based on what we know
-//!    let hash = vec![1, 2, 3, 4];
-//!    let request = RequestBuilder::new("GET", "localhost", 443, "/resource")
-//!        .hash(&hash[..])
-//!        .request();
+//! // build a request object based on what we know
+//! let hash = vec![1, 2, 3, 4];
+//! let request = RequestBuilder::new("GET", "localhost", 443, "/resource")
+//!     .hash(&hash[..])
+//!     .request();
 //!
-//!    let key = Key::new(vec![99u8; 32], SHA256).unwrap();
-//!    let one_week_in_secs = 7 * 24 * 60 * 60;
-//!    if !request.validate_header(&hdr, &key, Duration::from_secs(5200 * one_week_in_secs)) {
-//!        panic!("header validation failed. Is it 2117 already?");
-//!    }
+//! let key = Key::new(vec![99u8; 32], SHA256).unwrap();
+//! let one_week_in_secs = 7 * 24 * 60 * 60;
+//! if !request.validate_header(&hdr, &key, Duration::from_secs(5200 * one_week_in_secs)) {
+//!     panic!("header validation failed. Is it 2117 already?");
 //! }
 //! ```
 //!

--- a/src/mac.rs
+++ b/src/mac.rs
@@ -135,7 +135,7 @@ mod test {
             None,
         )
         .unwrap();
-        println!("got {:?}", mac);
+        println!("got {mac:?}");
         assert!(
             mac.0
                 == vec![
@@ -162,7 +162,7 @@ mod test {
             None,
         )
         .unwrap();
-        println!("got {:?}", mac);
+        println!("got {mac:?}");
         assert!(
             mac.0
                 == vec![
@@ -189,7 +189,7 @@ mod test {
             Some(&ext),
         )
         .unwrap();
-        println!("got {:?}", mac);
+        println!("got {mac:?}");
         assert!(
             mac.0
                 == vec![

--- a/src/response.rs
+++ b/src/response.rs
@@ -27,10 +27,10 @@ pub struct Response<'a> {
 impl<'a> Response<'a> {
     /// Create a new Header for this response, based on the given request and request header
     pub fn make_header(&self, key: &Key) -> Result<Header> {
-        let mac;
+        
         let ts = self.req_header.ts.ok_or(Error::MissingTs)?;
         let nonce = self.req_header.nonce.as_ref().ok_or(Error::MissingNonce)?;
-        mac = Mac::new(
+        let mac = Mac::new(
             MacType::Response,
             key,
             ts,
@@ -49,14 +49,8 @@ impl<'a> Response<'a> {
             None,
             None,
             Some(mac),
-            match self.ext {
-                None => None,
-                Some(v) => Some(v.to_string()),
-            },
-            match self.hash {
-                None => None,
-                Some(v) => Some(v.to_vec()),
-            },
+            self.ext.map(|v| v.to_string()),
+            self.hash.map(|v| v.to_vec()),
             None,
             None,
         )
@@ -86,14 +80,8 @@ impl<'a> Response<'a> {
                 return false;
             }
         };
-        let header_ext = match response_header.ext {
-            Some(ref ext) => Some(&ext[..]),
-            None => None,
-        };
-        let header_hash = match response_header.hash {
-            Some(ref hash) => Some(&hash[..]),
-            None => None,
-        };
+        let header_ext = response_header.ext.as_ref().map(|ext| &ext[..]);
+        let header_hash = response_header.hash.as_ref().map(|hash| &hash[..]);
 
         // first verify the MAC
         match Mac::new(

--- a/src/response.rs
+++ b/src/response.rs
@@ -27,7 +27,6 @@ pub struct Response<'a> {
 impl<'a> Response<'a> {
     /// Create a new Header for this response, based on the given request and request header
     pub fn make_header(&self, key: &Key) -> Result<Header> {
-        
         let ts = self.req_header.ts.ok_or(Error::MissingTs)?;
         let nonce = self.req_header.nonce.as_ref().ok_or(Error::MissingNonce)?;
         let mac = Mac::new(


### PR DESCRIPTION
This fixes lints from the nightly version of Rust, but the CI tests with
1.61, so we'll see how that goes.                                                                                                                                                                                                                                                                                              